### PR TITLE
Add support for using namespace scoped role resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ Once you have your storage settings in the values file, install the chart like t
 helm install pulsar datastax-pulsar/pulsar --namespace pulsar --values storage_values.yaml --create-namespace
 ```
 
+## Using namespace scoped RBAC resources
+
+By default, the Helm deployment uses `ClusterRole` and `ClusterRoleBinding` resources for defining access for service accounts. These resources get created outside of the namespace defined for deployment.
+
+It is possible to use namespace scoped `Role` and `RoleBinding` resources by setting `rbac.clusterRoles` to `false`.
+
+```
+rbac:
+  # use namespaces Role and RoleBinding resources
+  clusterRoles: false
+```
+
 ## Installing Pulsar for development
 
 This chart is designed for production use, but it can be used in development enviroments. To use this chart in a development environment (ex minikube), you need to:

--- a/helm-chart-sources/pulsar/templates/dns/dns-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/dns/dns-rbac.yaml
@@ -15,7 +15,7 @@
 #
 #
 
-{{- if .Values.extra.usedns }}
+{{- if and .Values.rbac.create .Values.extra.usedns }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -23,10 +23,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ if .Values.rbac.clusterRoles }}ClusterRole{{ else }}Role{{ end }}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.dns.component }}"
+  {{- if not .Values.rbac.clusterRoles }}
   namespace: {{ .Release.Namespace }}
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources: ["services","endpoints","pods"]
@@ -39,12 +41,15 @@ rules:
   verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ if .Values.rbac.clusterRoles }}ClusterRoleBinding{{ else }}RoleBinding{{ end }}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.dns.component }}-viewer"
+  {{- if not .Values.rbac.clusterRoles }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}  
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ if .Values.rbac.clusterRoles }}ClusterRole{{ else }}Role{{ end }}
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.dns.component }}"
 subjects:
 - kind: ServiceAccount

--- a/helm-chart-sources/pulsar/templates/function/function-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-rbac.yaml
@@ -15,11 +15,14 @@
 #
 #
 
-{{- if .Values.extra.function }}
+{{- if and .Values.rbac.create .Values.extra.function }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ if .Values.rbac.clusterRoles }}ClusterRole{{ else }}Role{{ end }}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"
+  {{- if not .Values.rbac.clusterRoles }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources:
@@ -43,12 +46,15 @@ metadata:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ if .Values.rbac.clusterRoles }}ClusterRoleBinding{{ else }}RoleBinding{{ end }}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"
+  {{- if not .Values.rbac.clusterRoles }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ if .Values.rbac.clusterRoles }}ClusterRole{{ else }}Role{{ end }}
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"
 subjects:
 - kind: ServiceAccount

--- a/helm-chart-sources/pulsar/templates/function/function-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-rbac.yaml
@@ -26,18 +26,16 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - services
-  - configmaps
   - pods
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
+  verbs: ["list"]
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["get", "create", "delete"]
+- apiGroups: ["apps"]
   resources:
   - statefulsets
-  verbs:
-  - '*'
+  verbs: ["get", "create", "delete"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm-chart-sources/pulsar/templates/proxy/burnell-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/burnell-rbac.yaml
@@ -26,22 +26,17 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - services
-  - configmaps
-  - pods
   - secrets
+  verbs: ["get", "create"]
+- apiGroups: [""]
+  resources:
   - namespaces
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
+  verbs: ["list"]
+- apiGroups: ["apps"]
   resources:
   - deployments
   - statefulsets
-  - secrets
-  - namespaces
-  verbs:
-  - '*'
+  verbs: ["list"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm-chart-sources/pulsar/templates/proxy/burnell-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/burnell-rbac.yaml
@@ -15,11 +15,14 @@
 #
 #
 
-{{- if or .Values.enableProvisionContainer .Values.extra.pulsarHealer .Values.extra.pulsarAdminConsole }}
+{{- if and .Values.rbac.create ( or .Values.enableProvisionContainer .Values.extra.pulsarHealer .Values.extra.pulsarAdminConsole ) }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ if .Values.rbac.clusterRoles }}ClusterRole{{ else }}Role{{ end }}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-burnell"
+  {{- if not .Values.rbac.clusterRoles }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources:
@@ -47,12 +50,15 @@ metadata:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ if .Values.rbac.clusterRoles }}ClusterRoleBinding{{ else }}RoleBinding{{ end }}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-burnell"
+  {{- if not .Values.rbac.clusterRoles }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ if .Values.rbac.clusterRoles }}ClusterRole{{ else }}Role{{ end }}
   name: "{{ template "pulsar.fullname" . }}-burnell"
 subjects:
 - kind: ServiceAccount

--- a/helm-chart-sources/pulsar/templates/proxy/burnell-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/burnell-rbac.yaml
@@ -15,7 +15,7 @@
 #
 #
 
-{{- if and .Values.rbac.create ( or .Values.enableProvisionContainer .Values.extra.pulsarHealer .Values.extra.pulsarAdminConsole ) }}
+{{- if and .Values.rbac.create ( or .Values.autoRecovery.enableProvisionContainer .Values.extra.pulsarHealer .Values.extra.pulsarAdminConsole ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: {{ if .Values.rbac.clusterRoles }}ClusterRole{{ else }}Role{{ end }}
 metadata:

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-rbac.yaml
@@ -15,11 +15,14 @@
 #
 #
 
-{{- if .Values.extra.pulsarHeartbeat }}
+{{- if and .Values.rbac.create .Values.extra.pulsarHeartbeat }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ if .Values.rbac.clusterRoles }}ClusterRole{{ else }}Role{{ end }}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarHeartbeat.component }}"
+  {{- if not .Values.rbac.clusterRoles }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 rules:
 - apiGroups: [""]
   resources:
@@ -44,12 +47,15 @@ metadata:
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ if .Values.rbac.clusterRoles }}ClusterRoleBinding{{ else }}RoleBinding{{ end }}
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarHeartbeat.component }}"
+  {{- if not .Values.rbac.clusterRoles }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ if .Values.rbac.clusterRoles }}ClusterRole{{ else }}Role{{ end }}
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarHeartbeat.component }}"
 subjects:
 - kind: ServiceAccount

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-rbac.yaml
@@ -26,19 +26,13 @@ metadata:
 rules:
 - apiGroups: [""]
   resources:
-  - services
-  - configmaps
   - pods
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
+  verbs: ["list"]
+- apiGroups: ["apps"]
   resources:
   - deployments
   - statefulsets
-  verbs:
-  - '*'
+  verbs: ["list"]
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -24,6 +24,13 @@ fullnameOverride: pulsar
 # DNS name for loadbalancer
 dnsName: pulsar.example.com
 
+# RBAC resource configuration
+rbac:
+  # create ClusterRole/Role and ClusterRoleBinding/RoleBinding resources
+  create: true
+  # use ClusterRole and ClusterRoleBinding resources when set to true
+  # use namespaced Role and RoleBinding resources when set to false
+  clusterRoles: true
 # Global node selector
 # If set, this will apply to all components
 # Individual components can be set to a different node


### PR DESCRIPTION
### Motivation

In restricted k8s environments (such as Openshift), it is a common practice to limit admin access to a namespace scope. 
Currently it's not possible to deploy the helm chart with namespace admin access since non-namespace scoped resources such as ClusterRole and ClusterRoleBinding are used. The solution is to use namespace level Role and RoleBinding resources.

### Modifications

- Add RBAC configuration to values.yaml
```yaml
# RBAC resource configuration
rbac:
  # create ClusterRole/Role and ClusterRoleBinding/RoleBinding resources
  create: true
  # use ClusterRole and ClusterRoleBinding resources when set to true
  # use namespaced Role and RoleBinding resources when set to false
  clusterRoles: true
```

- Use `.Values.rbac.create` and `.Values.rbac.clusterRoles` in the resource templates which create the RBAC resources
  - Conditionally use `ClusterRole` / `Role` and `ClusterRoleBinding` / `RoleBinding`
  - Skip RBAC configuration when `.Values.rbac.create` isn't set
 