### PR TITLE
Use non-root container for nginx in pulsar-admin-console deployment

### DIFF
--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-deployment.yaml
@@ -57,14 +57,14 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.pulsarAdminConsole.gracePeriod }}
       containers:
       - name: nginx
-        image: nginx
+        image: nginxinc/nginx-unprivileged:stable-alpine
         imagePullPolicy: {{ .Values.image.pulsarAdminConsole.pullPolicy }}
         ports:
         - name: "nginx"
-          containerPort: 80
+          containerPort: 8080
         {{- if .Values.enableTls }}
         - name: "nginx-tls"
-          containerPort: 443
+          containerPort: 8443
         {{- end }}
         volumeMounts:
         - mountPath: /etc/nginx
@@ -78,13 +78,13 @@ spec:
         livenessProbe:
           httpGet:
             path: /ruok
-            port: 80
+            port: 8080
           initialDelaySeconds: {{ .Values.pulsarAdminConsole.probe.liveness.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.pulsarAdminConsole.probe.liveness.timeoutSeconds }}
         readinessProbe:
           httpGet:
             path: /ruok
-            port: 80
+            port: 8080
           initialDelaySeconds: {{ .Values.pulsarAdminConsole.probe.readiness.initialDelaySeconds }}
           timeoutSeconds: {{ .Values.pulsarAdminConsole.probe.readiness.timeoutSeconds }}
         resources:

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-ingress.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-ingress.yaml
@@ -39,11 +39,11 @@ spec:
           - path: /
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}"
-              servicePort: 80
+              servicePort: 8080
           - path: /ws/
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}"
-              servicePort: 80
+              servicePort: 8080
   {{- if and .Values.enableTls .Values.pulsarAdminConsole.ingress.enableTls}}
   tls:
   - hosts:

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -32,10 +32,17 @@ data:
   nginx.conf: |
     worker_processes  3;
     error_log  /var/log/nginx/error.log;
+    pid        /tmp/nginx.pid;
     events {
       worker_connections  10240;
     }
     http {
+      proxy_temp_path /tmp/proxy_temp;
+      client_body_temp_path /tmp/client_temp;
+      fastcgi_temp_path /tmp/fastcgi_temp;
+      uwsgi_temp_path /tmp/uwsgi_temp;
+      scgi_temp_path /tmp/scgi_temp;
+
       log_format  main
               'remote_addr:$remote_addr\t'
               'time_local:$time_local\t'
@@ -138,9 +145,9 @@ data:
               proxy_pass http://http-pulsar-proxy$uri$is_args$args;
             }
 
-            listen 80 default_server;
+            listen 8080 default_server;
             {{- if .Values.tlsEnabled }}
-            listen 443 ssl;
+            listen 8443 ssl;
             ssl_certificate /certs/tls.crt;
             ssl_certificate_key /certs/tls.key;
             ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
@@ -159,7 +166,7 @@ data:
 
         }
 
-        listen 8080 ;
+        listen 8081 ;
 
       }
 

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
@@ -34,9 +34,9 @@ spec:
   type: {{ .Values.pulsarAdminConsole.service.type }}
   ports:
   - name: http
-    port: 80
+    port: 8080
   - name: https
-    port: 443
+    port: 8443
   selector:
     app: {{ template "pulsar.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
### Motivation

OpenShift deployment fails for pulsar-admin-console because of the nginx configuration used in pulsar-admin-console deployment which doesn't support running as non-root. The failure message is
```
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf is not a file or does not exist
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
2021/07/05 16:30:46 [emerg] 1#1: mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
nginx: [emerg] mkdir() "/var/cache/nginx/client_temp" failed (13: Permission denied)
```

### Modifications

- switch to use [`nginxinc/nginx-unprivileged:stable-alpine` base image](https://hub.docker.com/r/nginxinc/nginx-unprivileged) for nginx which supports non-root access.
- update custom nginx.conf to support non-root access
- **change listening ports 80 -> 8080 , 443 -> 8443**  since non-root containers cannot bind to ports <1024 by default.
 