### PR TITLE
Use chart version v2 since dependencies is only allowed for v2

### DIFF
--- a/helm-chart-sources/pulsar/Chart.yaml
+++ b/helm-chart-sources/pulsar/Chart.yaml
@@ -15,7 +15,8 @@
 #  
 # 
 
-apiVersion: v1
+apiVersion: v2
+type: application
 appVersion: "2.7.2"
 description: Apache Pulsar Helm chart for Kubernetes
 name: pulsar
@@ -27,6 +28,6 @@ dependencies:
   condition: kube-prometheus-stack.enabled
 - name: cert-manager
   version: v1.1.x
-  repository: https://charts.jetstack.io 
+  repository: https://charts.jetstack.io
   condition: cert-manager.enabled
 


### PR DESCRIPTION
- helm lint complained about invalid apiVersion in Chart.yml
- should be v2