### PR TITLE
Compare version to release branch in linting

### DIFF
--- a/tests/ct.yaml
+++ b/tests/ct.yaml
@@ -16,7 +16,7 @@
 #
 
 remote: origin
-target-branch: master
+target-branch: release
 helm-extra-args: "--timeout 600s"
 chart-dirs:
   - helm-chart-sources


### PR DESCRIPTION
- ct lint fails if the chart version isn't bumped for each PR. This doesn't make sense.
- the target branch should be `release` in `ct.yaml` config file