### PR TITLE
Revisit instructions for triggering a release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@ To trigger a release:
 ```
 git fetch
 git checkout release
-git rebase origin/master
+git merge origin/master
 ```
 
 Now update the versions in the *Chart.yaml* for each chart that has changed. Then push the change to origin:


### PR DESCRIPTION
- rebasing the release branch doesn't make sense since it would require a force push when updating the upstream repository
- replace `git rebase origin/master` with `git merge origin/master` in the instructions