### PR TITLE
Add imagePullSecrets to Function worker sts

### DIFF
--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -52,6 +52,10 @@ spec:
       {{- end }}
 {{ toYaml .Values.function.annotations | indent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}


### PR DESCRIPTION
While working on something else, I noticed that we don't pass in the parameterized `.Values.imagePullSecrets` to the function work sts. This PR adds that to the yaml. I tested the change with a docker image that required a pull secret.