### PR TITLE
Don't require version increment for every merge to master

### DIFF
--- a/tests/ct.yaml
+++ b/tests/ct.yaml
@@ -16,6 +16,7 @@
 #
 
 remote: origin
+check-version-increment: false
 target-branch: release
 helm-extra-args: "--timeout 600s"
 chart-dirs:


### PR DESCRIPTION
The current `ct lint` command only passes when the version has been incremented. I don't believe we want to bump the version for all changes, so I propose disabling the requirement in this PR.