### PR TITLE
Add Keycloak Deployment as Authentication/Identity Provider for Pulsar

### DIFF
--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -15,6 +15,38 @@
 #
 #
 
+# Must use an image with the AuthenticationProvider Jar for broker, function, and proxy
+image:
+  broker:
+    repository: datastax/lunastreaming-all
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  function:
+    repository: datastax/lunastreaming-all
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  proxy:
+    repository: datastax/lunastreaming-all
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  zookeeper:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  bookkeeper:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  bastion:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  pulsarSQL:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  # TODO add in the updated Pulsar Admin Console when it is released
+
 enableAntiAffinity: false
 # TLS is not included in this example. It is recommended to use TLS to ensure the authenticity and security of tokens.
 enableTls: false

--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -145,9 +145,6 @@ proxy:
 grafanaDashboards:
   enabled: true
 
-imagePullSecrets:
-  - name: "regcred"
-
 pulsarAdminConsole:
   replicaCount: 1
   authMode: openidconnect

--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -1,0 +1,130 @@
+#
+#  Copyright 2021 DataStax, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+enableAntiAffinity: false
+# TLS is not included in this example. It is recommended to use TLS to ensure the authenticity and security of tokens.
+enableTls: false
+enableTokenAuth: true
+restartOnConfigMapChange:
+  enabled: true
+extra:
+  function: true
+  burnell: true
+  burnellLogCollector: true
+  pulsarHeartbeat: true
+  pulsarAdminConsole: true
+
+keycloak:
+  enabled: true
+  auth:
+    adminUser: "admin"
+    adminPassword: "F3LVqnxqMmkCQkvyPdJiwXodqQncK@"
+
+zookeeper:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+
+bookkeeper:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  configData:
+    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+
+broker:
+  component: broker
+  replicaCount: 1
+  ledger:
+    defaultEnsembleSize: 1
+    defaultAckQuorum: 1
+    defaultWriteQuorum: 1
+  resources:
+    requests:
+      memory: 600Mi
+      cpu: 0.3
+  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID"
+  configData:
+    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    # Note that the realm is created after deployment, and should match the realm that will be created for clients/users
+    PULSAR_PREFIX_openIDAllowedTokenIssuers: "http://test-keycloak/auth/realms/pulsar"
+
+autoRecovery:
+  enableProvisionContainer: true
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 0.3
+
+function:
+  replicaCount: 1
+  functionReplicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+  configData:
+    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PF_openIDAllowedTokenIssuers: "http://test-keycloak/auth/realms/pulsar"
+
+proxy:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  wsResources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID"
+  wsAuthenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+  configData:
+    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    # Note that the realm is created after deployment, and should match the realm that will be created for clients/users
+    PULSAR_PREFIX_openIDAllowedTokenIssuers: "http://test-keycloak/auth/realms/pulsar"
+  autoPortAssign:
+    enablePlainTextWithTLS: true
+  service:
+    autoPortAssign:
+      enabled: true
+
+grafanaDashboards:
+  enabled: true
+
+imagePullSecrets:
+  - name: "regcred"
+
+pulsarAdminConsole:
+  replicaCount: 1
+  authMode: openidconnect
+
+kube-prometheus-stack:
+  enabled: true
+  prometheusOperator:
+    enabled: true
+  grafana:
+    enabled: true
+    adminPassword: e9JYtk83*4#PM8
+

--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -45,7 +45,6 @@ image:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
     tag: 2.8.0_1.1.1
-  # TODO add in the updated Pulsar Admin Console when it is released
 
 enableAntiAffinity: false
 # TLS is not included in this example. It is recommended to use TLS to ensure the authenticity and security of tokens.
@@ -98,8 +97,6 @@ broker:
   authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID"
   configData:
     PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
-    # Note that the realm is created after deployment, and should match the realm that will be created for clients/users
-    PULSAR_PREFIX_openIDAllowedTokenIssuers: "http://test-keycloak/auth/realms/pulsar"
 
 autoRecovery:
   enableProvisionContainer: true
@@ -118,7 +115,6 @@ function:
   authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
   configData:
     PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
-    PF_openIDAllowedTokenIssuers: "http://test-keycloak/auth/realms/pulsar"
 
 proxy:
   replicaCount: 1
@@ -134,8 +130,6 @@ proxy:
   wsAuthenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
   configData:
     PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
-    # Note that the realm is created after deployment, and should match the realm that will be created for clients/users
-    PULSAR_PREFIX_openIDAllowedTokenIssuers: "http://test-keycloak/auth/realms/pulsar"
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:

--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -151,6 +151,8 @@ imagePullSecrets:
 pulsarAdminConsole:
   replicaCount: 1
   authMode: openidconnect
+  # The client id used when authenticating with keycloak
+  oauthClientId: "pulsar-admin-console"
 
 kube-prometheus-stack:
   enabled: true

--- a/helm-chart-sources/pulsar/Chart.yaml
+++ b/helm-chart-sources/pulsar/Chart.yaml
@@ -36,3 +36,7 @@ dependencies:
   version: 0.0.7
   repository: https://slamdev.github.io/helm-charts
   condition: envoy.enabled
+- name: keycloak
+  version: 4.0.2
+  repository: https://charts.bitnami.com/bitnami
+  condition: keycloak.enabled

--- a/helm-chart-sources/pulsar/keycloak-realms/pulsar-realm.json
+++ b/helm-chart-sources/pulsar/keycloak-realms/pulsar-realm.json
@@ -1,0 +1,247 @@
+{
+  "id": "pulsar",
+  "realm": "pulsar",
+  "enabled": true,
+  "groups": [
+    {
+      "id": "3504da3f-6548-4423-9f1b-6153b8518731",
+      "name": "producer",
+      "path": "/producer",
+      "attributes": {
+        "sub": [
+          "producer"
+        ]
+      },
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    },
+    {
+      "id": "94d5911d-8394-4387-8b36-9d1102b1d519",
+      "name": "superuser",
+      "path": "/superuser",
+      "attributes": {
+        "sub": [
+          "superuser"
+        ]
+      },
+      "realmRoles": [],
+      "clientRoles": {},
+      "subGroups": []
+    }
+  ],
+  "users": [
+    {
+      "id": "1bdaebc5-30ca-455b-b1b2-a064e11c9896",
+      "createdTimestamp": 1627407272587,
+      "username": "service-account-pulsar-admin-example-client",
+      "enabled": true,
+      "totp": false,
+      "emailVerified": false,
+      "serviceAccountClientId": "pulsar-admin-example-client",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-pulsar"
+      ],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "clients": [
+    {
+      "id": "6767dd5d-28e0-421e-a276-c917dc46a8af",
+      "clientId": "pulsar-admin-console",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "42b5bd7c-235a-46c7-a712-40cd54fd0791",
+          "name": "user-attribute-to-sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "sub",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "sub",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "da5d898e-5d3a-4df9-9d5f-3c7f42c408e9",
+      "clientId": "pulsar-admin-example-client",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "b6986d12-fe9e-488a-958d-21968a3f327b",
+          "name": "hard-coded-sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "admin",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "sub",
+            "access.tokenResponse.claim": "false"
+          }
+        },
+        {
+          "id": "1e3c4968-cb0e-4494-856a-d3b43b86b22f",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientId",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6afab66c-438a-4ded-a57b-77f5f24c50af",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9091332a-42e9-4fa1-82ea-b8fa4049897a",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "roles",
+        "profile",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "keycloakVersion": "14.0.0"
+}

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-configmap.yaml
@@ -81,6 +81,7 @@ data:
         "running_env": "k8s",
         "use_token_list": "false",
         "auth_mode": "{{ .Values.pulsarAdminConsole.authMode }}",
+        "oauth_client_id": "superuser-client",
         "host_overrides": {
             {{- if .Values.pulsarAdminConsole.codeSampleUrl.useDnsName }}
             "pulsar": "pulsar+ssl://{{ .Values.dnsName }}:6651",

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-configmap.yaml
@@ -81,7 +81,7 @@ data:
         "running_env": "k8s",
         "use_token_list": "false",
         "auth_mode": "{{ .Values.pulsarAdminConsole.authMode }}",
-        "oauth_client_id": "superuser-client",
+        "oauth_client_id": "{{ .Values.pulsarAdminConsole.oauthClientId }}",
         "host_overrides": {
             {{- if .Values.pulsarAdminConsole.codeSampleUrl.useDnsName }}
             "pulsar": "pulsar+ssl://{{ .Values.dnsName }}:6651",

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-deployment.yaml
@@ -49,6 +49,10 @@ spec:
 {{ toYaml .Values.pulsarAdminConsole.annotations | indent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: "{{ template "pulsar.fullname" . }}-burnell"
     {{- if .Values.pulsarAdminConsole.tolerations }}
       tolerations:
@@ -102,7 +106,7 @@ spec:
           containerPort: 6455
         volumeMounts:
           - name: dashboardconfig
-            mountPath: /root/dashboard/dist/config-override.js
+            mountPath: /home/appuser/dashboard/dist/config-override.js
             subPath: config-override.js
           {{- if .Values.enableTls }}
           - name: certs

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -73,6 +73,12 @@ data:
         server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8964;
       }
 
+      {{- if .Values.keycloak.enabled }}
+      upstream {{ .Release.Name }}-keycloak {
+        server {{ .Release.Name }}-keycloak:80;
+      }
+      {{- end }}
+
       server {
 
             location /ruok {
@@ -144,6 +150,13 @@ data:
               rewrite ^/api/v1/{{ template "pulsar.fullname" . }}/(.*)$ /admin/v2/$1 break;
               proxy_pass http://http-pulsar-proxy$uri$is_args$args;
             }
+
+            {{- if .Values.keycloak.enabled }}
+            location ^~ /api/v1/auth/token {
+              rewrite  ^.*$ /auth/realms/{{ .Values.keycloakRealm }}/protocol/openid-connect/token break;
+              proxy_pass http://{{ .Release.Name }}-keycloak$uri$is_args$args;
+            }
+            {{- end }}
 
             listen 8080 default_server;
             {{- if .Values.tlsEnabled }}

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -151,10 +151,11 @@ data:
               proxy_pass http://http-pulsar-proxy$uri$is_args$args;
             }
 
+            # For use when keycloak is the authentication/identity provider
             {{- if .Values.keycloak.enabled }}
             location ^~ /api/v1/auth/token {
-              rewrite  ^.*$ /auth/realms/{{ .Values.keycloakRealm }}/protocol/openid-connect/token break;
-              proxy_pass http://{{ .Release.Name }}-keycloak$uri$is_args$args;
+              rewrite  ^.*$ /auth/realms/{{ .Values.keycloak.realm }}/protocol/openid-connect/token break;
+              proxy_pass {{ template "pulsar.get.http.or.https" . }}{{ .Release.Name }}-keycloak$uri$is_args$args;
             }
             {{- end }}
 

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -75,7 +75,11 @@ data:
 
       {{- if .Values.keycloak.enabled }}
       upstream {{ .Release.Name }}-keycloak {
-        server {{ .Release.Name }}-keycloak:80;
+         {{- if .Values.enableTls }}
+         server {{ .Release.Name }}-keycloak:443;
+         {{- else }}
+         server {{ .Release.Name }}-keycloak:80;
+         {{- end }}
       }
       {{- end }}
 

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -102,7 +102,7 @@ data:
   {{- if .Values.broker.extraAuthProvider }}
   authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken,{{ .Values.broker.extraAuthProvider }}"
   {{- else }}
-  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
+  authenticationProviders: "{{ .Values.broker.authenticationProviders }}"
   {{- end }}
   {{- end }}
 {{- if .Values.enableTls }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -104,6 +104,9 @@ data:
   {{- else }}
   authenticationProviders: "{{ .Values.broker.authenticationProviders }}"
   {{- end }}
+  {{- if .Values.keycloak.enabled }}
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local/auth/realms/{{ .Values.keycloak.realm }}"
+  {{- end }}
   {{- end }}
 {{- if .Values.enableTls }}
   tlsEnabled: "true"

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -104,6 +104,9 @@ data:
   {{- else }}
   authenticationProviders: "{{ .Values.brokerSts.authenticationProviders }}"
   {{- end }}
+  {{- if .Values.keycloak.enabled }}
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local/auth/realms/{{ .Values.keycloak.realm }}"
+  {{- end }}
   {{- end }}
 {{- if .Values.enableTls }}
   tlsEnabled: "true"

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -100,9 +100,9 @@ data:
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
   brokerClientAuthenticationParameters: "file:///pulsar/token-superuser/superuser.jwt"
   {{- if .Values.brokerSts.extraAuthProvider }}
-  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken,{{ .Values.brokerSts.extraAuthProvider }}"
+  authenticationProviders: "{{ .Values.brokerSts.authenticationProviders }},{{ .Values.brokerSts.extraAuthProvider }}"
   {{- else }}
-  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
+  authenticationProviders: "{{ .Values.brokerSts.authenticationProviders }}"
   {{- end }}
   {{- end }}
 {{- if .Values.enableTls }}

--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -114,7 +114,7 @@ data:
     authenticationEnabled: "true"
     authorizationEnabled: "true"
     authorizationProvider: "org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider"
-    authenticationProviders: [org.apache.pulsar.broker.authentication.AuthenticationProviderToken, org.apache.pulsar.broker.authentication.AuthenticationProviderTls]
+    authenticationProviders: [{{.Values.function.authenticationProviders}}]
     properties:
       tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
     clientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"

--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -114,6 +114,7 @@ data:
     authenticationEnabled: "true"
     authorizationEnabled: "true"
     authorizationProvider: "org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider"
+    authenticationProviders: [org.apache.pulsar.broker.authentication.AuthenticationProviderToken, org.apache.pulsar.broker.authentication.AuthenticationProviderTls]
     properties:
       tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
     clientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"

--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -114,7 +114,6 @@ data:
     authenticationEnabled: "true"
     authorizationEnabled: "true"
     authorizationProvider: "org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider"
-    authenticationProviders: [org.apache.pulsar.broker.authentication.AuthenticationProviderToken, org.apache.pulsar.broker.authentication.AuthenticationProviderTls]
     properties:
       tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
     clientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"

--- a/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
@@ -37,6 +37,9 @@ data:
   tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
   brokerClientAuthenticationParameters: "file:///pulsar/token-superuser/superuser.jwt"
+  {{- if .Values.keycloak.enabled }}
+  PF_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local/auth/realms/{{ .Values.keycloak.realm }}"
+  {{- end }}
   {{- end }}
 {{ toYaml .Values.function.configData | indent 2 }}
   # Workaround for double-quoted values in old values files

--- a/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
@@ -32,7 +32,7 @@ data:
   {{- if .Values.enableTokenAuth }}
   authorizationEnabled: "true"
   authenticationEnabled: "true"
-  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+  authenticationProviders: "{{ .Values.function.authenticationProviders }}"
   superUserRoles: "{{ .Values.superUserRoles }}"
   tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"

--- a/helm-chart-sources/pulsar/templates/keycloak/keycloak-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/keycloak/keycloak-configmap.yaml
@@ -1,0 +1,33 @@
+#
+#  Copyright 2021 DataStax, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+{{- if .Values.keycloak.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "realm-config"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    cluster: {{ template "pulsar.fullname" . }}
+data:
+  pulsar-realm.json: |-
+{{ .Files.Get "pulsar-realms/pulsar-realm.json" | indent 4 }}
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/burnell-rbac.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/burnell-rbac.yaml
@@ -27,7 +27,7 @@ rules:
 - apiGroups: [""]
   resources:
   - secrets
-  verbs: ["get", "create"]
+  verbs: ["get", "create", "list"]
 - apiGroups: [""]
   resources:
   - namespaces

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -110,6 +110,9 @@ data:
   {{- else }}
   authenticationProviders: "{{ .Values.proxy.authenticationProviders }}"
   {{- end }}
+  {{- if .Values.keycloak.enabled }}
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local/auth/realms/{{ .Values.keycloak.realm }}"
+  {{- end }}
   tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
   brokerClientAuthenticationParameters: "file:///pulsar/token-proxy/proxy.jwt"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -106,9 +106,9 @@ data:
   authorizationEnabled: "true"
   superUserRoles: "{{ .Values.superUserRoles }}"
   {{- if .Values.proxy.extraAuthProvider }}
-  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken,{{ .Values.proxy.extraAuthProvider }}"
+  authenticationProviders: "{{ .Values.proxy.authenticationProviders }},{{ .Values.proxy.extraAuthProvider }}"
   {{- else }}
-  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
+  authenticationProviders: "{{ .Values.proxy.authenticationProviders }}"
   {{- end }}
   tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -57,6 +57,9 @@ data:
   tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
   authorizationEnabled: "true"
   superUserRoles: "{{ .Values.superUserRoles }}"
+  {{- if .Values.keycloak.enabled }}
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local/auth/realms/{{ .Values.keycloak.realm }}"
+  {{- end }}
   {{- end }}
 {{- if and .Values.enableTls }}
   webServicePortTls: "{{ .Values.proxy.wsProxyPortTls }}"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -53,7 +53,7 @@ data:
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
   brokerClientAuthenticationParameters: "file:///pulsar/token-websocket/websocket.jwt"
   authenticationEnabled: "true"
-  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+  authenticationProviders: "{{ .Values.proxy.wsAuthenticationProviders }}"
   tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
   authorizationEnabled: "true"
   superUserRoles: "{{ .Values.superUserRoles }}"

--- a/helm-chart-sources/pulsar/templates/utils/_helpers.tpl
+++ b/helm-chart-sources/pulsar/templates/utils/_helpers.tpl
@@ -25,6 +25,34 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Necessary to make proper names for keycloak services (note that it is important that
+the .Chart.Name for the keycloak dependent chart does not change.)
+*/}}
+{{- define "pulsar.keycloak.fullname" -}}
+{{- if .Values.keycloak.fullnameOverride -}}
+{{- .Values.keycloak.fullnameOverride | trunc 20 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "keycloak" .Values.keycloak.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 20 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 20 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the right protocol depending on whether or not tls is enabled.
+*/}}
+{{- define "pulsar.get.http.or.https" -}}
+{{- if .Values.enableTls -}}
+{{- print "https://" -}}
+{{- else -}}
+{{- print "http://" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "pulsar.chart" -}}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1383,7 +1383,7 @@ autoRecovery:
 pulsarAdminConsole:
   component: adminconsole
   defaultTenant: public
-  # authMode: none or k8s
+  # authMode: none, k8s, openidconnect
   authMode: none
   serverLogLevel: info
   createUserSecret:
@@ -1564,9 +1564,8 @@ pulsarHeartbeat:
 # Deploy Keycloak
 keycloak:
   enabled: false
-
-# The realm to use when the Pulsar Admin Console calls Keycloak (this configures nginx)
-keycloakRealm: "pulsar"
+  # The realm to use when the Pulsar Admin Console calls Keycloak (this configures nginx)
+  realm: "pulsar"
 
 # Deploy cert-manager
 cert-manager:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -794,6 +794,10 @@ broker:
   #   command: ["cp", "-r", "/pulsar-libs", "/jars" ]
   #   emptyDirPath: "/jars"
 
+  # Comma delimited list of authentication providers
+  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
+  # extraAuthProvider: this is now a deprecated field, use the `.Values.broker.authenticationProviders` field instead
+
   ## Broker configmap
   ## templates/broker-configmap.yaml
   ##
@@ -899,6 +903,10 @@ brokerSts:
   #   pullPolicy: IfNotPresent
   #   command: ["cp", "-r", "/pulsar-libs", "/jars" ]
   #   emptyDirPath: "/jars"
+
+  # Comma delimited list of authentication providers
+  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
+  # extraAuthProvider: this is now a deprecated field, use the `.Values.brokerSts.authenticationProviders` field instead
 
   ## Broker configmap
   ## templates/broker-configmap.yaml
@@ -1024,6 +1032,8 @@ function:
   #   command: ["cp", "-r", "/pulsar-connectors", "/connectors" ]
   #   emptyDirPath: "/connectors"
   #   mainContainerStartupCmd: "cp -f /connectors/pulsar-connectors/* /pulsar/connectors"
+
+  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
 
   ## Function configmap
   ## templates/function-configmap.yaml
@@ -1188,6 +1198,13 @@ proxy:
   #   pullPolicy: IfNotPresent
   #   command: ["cp", "-r", "/pulsar-libs", "/jars" ]
   #   emptyDirPath: "/jars"
+
+  # Comma delimited list of authentication providers
+  authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
+  # extraAuthProvider: this is now a deprecated field, use the `.Values.proxy.authenticationProviders` field instead
+  # Configure the wsAuthenticationProviders using .Values.proxy.configData
+  wsAuthenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+
   ## Proxy configmap
   ## templates/proxy-configmap.yaml
   ##
@@ -1543,6 +1560,13 @@ pulsarHeartbeat:
     latencyTest:
       intervalSeconds: 60
   service: {}
+
+# Deploy Keycloak
+keycloak:
+  enabled: false
+
+# The realm to use when the Pulsar Admin Console calls Keycloak (this configures nginx)
+keycloakRealm: "pulsar"
 
 # Deploy cert-manager
 cert-manager:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1564,7 +1564,19 @@ pulsarHeartbeat:
 # Deploy Keycloak
 keycloak:
   enabled: false
+  # https://www.keycloak.org/docs/latest/server_admin/#_export_import
+  extraStartupArgs: "-Dkeycloak.migration.action=import -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.file=/realm/pulsar-realm.json -Dkeycloak.migration.strategy=IGNORE_EXISTING"
+  extraVolumes: |
+    - name: realm-config
+      configMap:
+        name: realm-config
+  extraVolumeMounts: |
+    - name: realm-config
+      mountPath: "/realm/"
+      readOnly: true
+  # Config specific to this helm chart
   # The realm to use when the Pulsar Admin Console calls Keycloak (this configures nginx)
+  # Note that this is the realm in the pre-configured realm that ships with this helm chart
   realm: "pulsar"
 
 # Deploy cert-manager

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -352,7 +352,7 @@ image:
   pulsarAdminConsole:
     repository: datastax/pulsar-admin-console
     pullPolicy: IfNotPresent
-    tag: 1.0.0
+    tag: 1.1.0
 
 ## Tiered Storage
 ##


### PR DESCRIPTION
Add a keycloak integration and leverage the OpenID Connect plugin from https://github.com/datastax/pulsar-openid-connect-plugin. There are several configuration options. See the README for details.