### PR TITLE
Fix TLS in the Pulsar Admin Console's nginx.conf

### DIFF
--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -164,7 +164,7 @@ data:
             {{- end }}
 
             listen 8080 default_server;
-            {{- if .Values.tlsEnabled }}
+            {{- if .Values.enableTls }}
             listen 8443 ssl;
             ssl_certificate /certs/tls.crt;
             ssl_certificate_key /certs/tls.key;

--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-service.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-service.yaml
@@ -36,7 +36,7 @@ metadata:
     {{- end }}
 spec:
   ports:
-  {{- if and .Values.tlsEnabled .Values.tls.zookeeper.enabled }}
+  {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     - name: client-tls
       port: 2281
   {{- end }}
@@ -66,7 +66,7 @@ metadata:
     {{- end }}
 spec:
   ports:
-  {{- if and .Values.tlsEnabled .Values.tls.zookeeper.enabled }}
+  {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     - name: client-tls
       port: 2281
   {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-service.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-service.yaml
@@ -35,7 +35,7 @@ metadata:
     {{- end }}
 spec:
   ports:
-  {{- if and .Values.tlsEnabled .Values.tls.zookeeper.enabled }}
+  {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     - name: client-tls
       port: 2281
   {{- end }}
@@ -65,7 +65,7 @@ metadata:
     {{- end }}
 spec:
   ports:
-  {{- if and .Values.tlsEnabled .Values.tls.zookeeper.enabled }}
+  {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     - name: client-tls
       port: 2281
   {{- end }}


### PR DESCRIPTION
I was having trouble getting TLS to work with the Pulsar Admin Console. It looks like there was a typo in how we were determining whether or not TLS is enabled. It was likely copied over from a pulsar config, which uses the string `tlsEnabled`.

Note: I also fixed some zookeeper references that were using the pulsar configuration key instead of this helm chart's configuration key.