### PR TITLE
Fix Keycloak Realm ConfigMap

### DIFF
--- a/helm-chart-sources/pulsar/templates/keycloak/keycloak-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/keycloak/keycloak-configmap.yaml
@@ -29,5 +29,5 @@ metadata:
     cluster: {{ template "pulsar.fullname" . }}
 data:
   pulsar-realm.json: |-
-{{ .Files.Get "pulsar-realms/pulsar-realm.json" | indent 4 }}
+{{ .Files.Get "keycloak-realms/pulsar-realm.json" | indent 4 }}
 {{- end }}


### PR DESCRIPTION
There was a typo in the initial addition for this config map. The file is located at `keycloak-realms/pulsar-realm.json`.