### PR TITLE
Add port to keycloak URLs when using nondefault ports

### DIFF
--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -76,9 +76,9 @@ data:
       {{- if .Values.keycloak.enabled }}
       upstream {{ .Release.Name }}-keycloak {
          {{- if .Values.enableTls }}
-         server {{ .Release.Name }}-keycloak:443;
+         server {{ template "pulsar.keycloak.fullname" . }}:{{ .Values.keycloak.service.httpsPort }};
          {{- else }}
-         server {{ .Release.Name }}-keycloak:80;
+         server {{ template "pulsar.keycloak.fullname" . }}:{{ .Values.keycloak.service.port }};
          {{- end }}
       }
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -105,7 +105,7 @@ data:
   authenticationProviders: "{{ .Values.broker.authenticationProviders }}"
   {{- end }}
   {{- if .Values.keycloak.enabled }}
-  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local/auth/realms/{{ .Values.keycloak.realm }}"
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
   {{- end }}
   {{- end }}
 {{- if .Values.enableTls }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -105,7 +105,7 @@ data:
   authenticationProviders: "{{ .Values.brokerSts.authenticationProviders }}"
   {{- end }}
   {{- if .Values.keycloak.enabled }}
-  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local/auth/realms/{{ .Values.keycloak.realm }}"
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
   {{- end }}
   {{- end }}
 {{- if .Values.enableTls }}

--- a/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
@@ -38,7 +38,7 @@ data:
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
   brokerClientAuthenticationParameters: "file:///pulsar/token-superuser/superuser.jwt"
   {{- if .Values.keycloak.enabled }}
-  PF_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local/auth/realms/{{ .Values.keycloak.realm }}"
+  PF_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
   {{- end }}
   {{- end }}
 {{ toYaml .Values.function.configData | indent 2 }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -111,7 +111,7 @@ data:
   authenticationProviders: "{{ .Values.proxy.authenticationProviders }}"
   {{- end }}
   {{- if .Values.keycloak.enabled }}
-  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local/auth/realms/{{ .Values.keycloak.realm }}"
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
   {{- end }}
   tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -58,7 +58,7 @@ data:
   authorizationEnabled: "true"
   superUserRoles: "{{ .Values.superUserRoles }}"
   {{- if .Values.keycloak.enabled }}
-  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local/auth/realms/{{ .Values.keycloak.realm }}"
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
   {{- end }}
   {{- end }}
 {{- if and .Values.enableTls }}

--- a/helm-chart-sources/pulsar/templates/utils/_helpers.tpl
+++ b/helm-chart-sources/pulsar/templates/utils/_helpers.tpl
@@ -53,6 +53,27 @@ Get the right protocol depending on whether or not tls is enabled.
 {{- end -}}
 
 {{/*
+Get the colon and port number for the allow listed token issuers from Keycloak
+or return the empty string if the port is 80 or 443, as these won't be
+part of the issuer URL returned by keycloak in the JWT iss claim.
+*/}}
+{{- define "pulsar.keycloak.issuer.port" -}}
+{{- if .Values.enableTls -}}
+{{- if eq .Values.keycloak.service.httpsPort 443 -}}
+{{- print "" -}}
+{{- else -}}
+{{- printf ":%s" .Values.keycloak.service.httpsPort -}}
+{{- end -}}
+{{- else -}}
+{{- if eq .Values.keycloak.service.port 80 -}}
+{{- print "" -}}
+{{- else -}}
+{{- printf ":%s" .Values.keycloak.service.port -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "pulsar.chart" -}}

--- a/helm-chart-sources/pulsar/templates/utils/_helpers.tpl
+++ b/helm-chart-sources/pulsar/templates/utils/_helpers.tpl
@@ -56,19 +56,22 @@ Get the right protocol depending on whether or not tls is enabled.
 Get the colon and port number for the allow listed token issuers from Keycloak
 or return the empty string if the port is 80 or 443, as these won't be
 part of the issuer URL returned by keycloak in the JWT iss claim.
+We print the port number before checking for equality because the numbers are actually floats.
 */}}
 {{- define "pulsar.keycloak.issuer.port" -}}
 {{- if .Values.enableTls -}}
-{{- if eq .Values.keycloak.service.httpsPort 443 -}}
+{{- $port := printf "%v" .Values.keycloak.service.httpsPort -}}
+{{- if eq $port "443" -}}
 {{- print "" -}}
 {{- else -}}
-{{- printf ":%s" .Values.keycloak.service.httpsPort -}}
+{{- printf ":%v" .Values.keycloak.service.httpsPort -}}
 {{- end -}}
 {{- else -}}
-{{- if eq .Values.keycloak.service.port 80 -}}
+{{- $port := printf "%v" .Values.keycloak.service.port -}}
+{{- if eq $port "80" -}}
 {{- print "" -}}
 {{- else -}}
-{{- printf ":%s" .Values.keycloak.service.port -}}
+{{- printf ":%v" .Values.keycloak.service.port -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
The Bitnami Keycloak Helm Chart defaults to using ports 80 and 443 for the Keycloak service for http and https, respectively. When using a non default ports, they are added to the `iss` claim on the JWT. Because the check on the `iss` claim is a simple string equality check, the port needs to be included when using non-defaults.

Also, the Pulsar Admin Console Nginx config needs to use the port when forwarding traffic to Keycloak.