### PR TITLE
Parameterize Pulsar Admin Console Ports; Default to 80 and 443

### DIFF
--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
@@ -33,10 +33,7 @@ metadata:
 spec:
   type: {{ .Values.pulsarAdminConsole.service.type }}
   ports:
-  - name: http
-    port: 8080
-  - name: https
-    port: 8443
+{{ toYaml .Values.pulsarAdminConsole.service.ports | indent 2 }}
   selector:
     app: {{ template "pulsar.name" . }}
     release: {{ .Release.Name }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1429,8 +1429,12 @@ pulsarAdminConsole:
     annotations: {}
     type: LoadBalancer
     ports:
-    - name: server
-      port: 3100
+    - name: http
+      port: 80
+      targetPort: "nginx"
+    - name: https
+      port: 443
+      targetPort: "nginx-tls"
 
 ## Pulsar Component: Zoonavigator
 ## templates/zoonavigator-deployment.yaml


### PR DESCRIPTION
### Motivation
The pulsar admin console's ports are currently hard coded to 8080 and 8443. I see two limitations to this implementation.

First, there is no option to turn off the `http` port. Given that credentials are often sent to the PAC, I think it would be better to allow for users to close the `http` port on the load balancer service, if desired.

Second, services are allowed to have ports 80 and 443, even on OpenShift. These services are set up to map the incoming traffic to the right ports on the PAC deployment.

@cdbartholomew and @lhotari - I'm going to merge this when tests pass. Please take a look. If you see any issues, we can revert it.