### PR TITLE
Add Keycloak/TLS Example; Update non TLS Keycloak Example

### DIFF
--- a/examples/dev-values-auth.yaml
+++ b/examples/dev-values-auth.yaml
@@ -18,6 +18,8 @@
 enableAntiAffinity: false
 enableTls: false
 enableTokenAuth: true
+fixRootlessPermissions:
+  enabled: true
 restartOnConfigMapChange:
   enabled: true
 extra:

--- a/examples/dev-values-keycloak-auth-tls.yaml
+++ b/examples/dev-values-keycloak-auth-tls.yaml
@@ -20,31 +20,31 @@ image:
   broker:
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   function:
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   proxy:
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   zookeeper:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   bookkeeper:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   bastion:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   pulsarSQL:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
 
 fixRootlessPermissions:
   enabled: true

--- a/examples/dev-values-keycloak-auth-tls.yaml
+++ b/examples/dev-values-keycloak-auth-tls.yaml
@@ -98,9 +98,10 @@ keycloak:
   service:
     port: 80
     httpsPort: 443
-# TODO make this work; made keylcoak fail this way
-#  postgresql:
-#    postgresqlPassword: "xinf-2-doHTG._sMJi3*kZgQAabuet"
+  # It is recommended to override this password, as the dependent chart uses a default
+  # Here is an issue requesting that the default be removed: https://github.com/bitnami/charts/issues/7279.
+  postgresql:
+    postgresqlPassword: "xinf-2-doHTG._sMJi3*kZgQAabuet"
 
 zookeeper:
   replicaCount: 1

--- a/examples/dev-values-keycloak-auth-tls.yaml
+++ b/examples/dev-values-keycloak-auth-tls.yaml
@@ -1,0 +1,195 @@
+#
+#  Copyright 2021 DataStax, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+# Must use an image with the AuthenticationProvider Jar for broker, function, and proxy
+image:
+  broker:
+    repository: datastax/lunastreaming-all
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  function:
+    repository: datastax/lunastreaming-all
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  proxy:
+    repository: datastax/lunastreaming-all
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  zookeeper:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  bookkeeper:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  bastion:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+  pulsarSQL:
+    repository: datastax/lunastreaming
+    pullPolicy: IfNotPresent
+    tag: 2.8.0_1.1.1
+
+fixRootlessPermissions:
+  enabled: true
+enableAntiAffinity: false
+enableTls: true
+#tls:
+#  zookeeper:
+#    enabled: true
+enableTokenAuth: true
+restartOnConfigMapChange:
+  enabled: true
+extra:
+  function: false
+  burnell: true
+  burnellLogCollector: false
+  pulsarHeartbeat: true
+  pulsarAdminConsole: true
+
+cert-manager:
+  enabled: true
+
+createCertificates:
+  selfSigned:
+    enabled: true
+
+keycloak:
+  enabled: true
+  replicaCount: 2
+  # Required for > 1 replica
+  serviceDiscovery:
+    enabled: true
+  # Required for service discovery
+  rbac:
+    create: true
+  auth:
+    adminUser: "admin"
+    adminPassword: "F3LVqnxqMmkCQkvyPdJiwXodqQncK@"
+    tls:
+      enabled: true
+      # Must match the "keycloak-{{ .Values.tlsSecretName }}"
+      # When using Cert Manager, we generate a separate keystore.jks for keycloak than for the rest of pulsar.
+      # They are all share the same root ca cert mounted as the truststore.jks ensuring that the rest of the
+      # pulsar components trust Keycloak's cert chain.:ke:
+      jksSecret: "keycloak-pulsar-tls"
+      # These must be the same because the cert manager will use the keystorePassword to protect both
+      # the keystore.jks and the truststore.jks.
+      truststorePassword: "kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR"
+      keystorePassword: "kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR"
+      truststoreFilename: "truststore.jks"
+      keystoreFilename: "keystore.jks"
+  service:
+    port: 80
+    httpsPort: 443
+# TODO make this work; made keylcoak fail this way
+#  postgresql:
+#    postgresqlPassword: "xinf-2-doHTG._sMJi3*kZgQAabuet"
+
+zookeeper:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+
+bookkeeper:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  configData:
+    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+
+broker:
+  component: broker
+  replicaCount: 1
+  ledger:
+    defaultEnsembleSize: 1
+    defaultAckQuorum: 1
+    defaultWriteQuorum: 1
+  resources:
+    requests:
+      memory: 600Mi
+      cpu: 0.3
+  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID"
+  configData:
+    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info -Djavax.net.ssl.keyStore=/pulsar/certs/keystore.jks -Djavax.net.ssl.trustStore=/pulsar/certs/truststore.jks -Djavax.net.ssl.trustStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR -Djavax.net.ssl.keyStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR"
+
+autoRecovery:
+  enableProvisionContainer: true
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 0.3
+
+function:
+  replicaCount: 1
+  functionReplicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+  configData:
+    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info -Djavax.net.ssl.keyStore=/pulsar/certs/keystore.jks -Djavax.net.ssl.trustStore=/pulsar/certs/truststore.jks -Djavax.net.ssl.trustStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR -Djavax.net.ssl.keyStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR"
+
+proxy:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  wsResources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID"
+  wsAuthenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+  configData:
+    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info -Djavax.net.ssl.keyStore=/pulsar/certs/keystore.jks -Djavax.net.ssl.trustStore=/pulsar/certs/truststore.jks -Djavax.net.ssl.trustStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR -Djavax.net.ssl.keyStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR"
+  autoPortAssign:
+    enablePlainTextWithTLS: true
+  service:
+    autoPortAssign:
+      enabled: true
+
+grafanaDashboards:
+  enabled: true
+
+pulsarAdminConsole:
+  replicaCount: 1
+  authMode: openidconnect
+  # The client id used when authenticating with keycloak
+  oauthClientId: "pulsar-admin-console"
+
+kube-prometheus-stack:
+  enabled: true
+  prometheusOperator:
+    enabled: true
+  grafana:
+    enabled: true
+    adminPassword: e9JYtk83*4#PM8
+

--- a/examples/dev-values-keycloak-auth-tls.yaml
+++ b/examples/dev-values-keycloak-auth-tls.yaml
@@ -57,9 +57,9 @@ enableTokenAuth: true
 restartOnConfigMapChange:
   enabled: true
 extra:
-  function: false
+  function: true
   burnell: true
-  burnellLogCollector: false
+  burnellLogCollector: true
   pulsarHeartbeat: true
   pulsarAdminConsole: true
 
@@ -150,7 +150,8 @@ function:
     requests:
       memory: 512Mi
       cpu: 0.3
-  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+# This is dependent on https://github.com/apache/pulsar/pull/11468
+#  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
   configData:
     PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
     PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info -Djavax.net.ssl.keyStore=/pulsar/certs/keystore.jks -Djavax.net.ssl.trustStore=/pulsar/certs/truststore.jks -Djavax.net.ssl.trustStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR -Djavax.net.ssl.keyStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR"
@@ -184,6 +185,12 @@ pulsarAdminConsole:
   authMode: openidconnect
   # The client id used when authenticating with keycloak
   oauthClientId: "pulsar-admin-console"
+  service:
+    # Only expose the secure port
+    ports:
+      - name: https
+        port: 443
+        targetPort: "nginx-tls"
 
 kube-prometheus-stack:
   enabled: true

--- a/examples/dev-values-keycloak-auth-tls.yaml
+++ b/examples/dev-values-keycloak-auth-tls.yaml
@@ -150,8 +150,7 @@ function:
     requests:
       memory: 512Mi
       cpu: 0.3
-# This is dependent on https://github.com/apache/pulsar/pull/11468
-#  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
   configData:
     PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
     PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info -Djavax.net.ssl.keyStore=/pulsar/certs/keystore.jks -Djavax.net.ssl.trustStore=/pulsar/certs/truststore.jks -Djavax.net.ssl.trustStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR -Djavax.net.ssl.keyStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR"

--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -66,6 +66,10 @@ keycloak:
   auth:
     adminUser: "admin"
     adminPassword: "F3LVqnxqMmkCQkvyPdJiwXodqQncK@"
+  # It is recommended to override this password, as the dependent chart uses a default
+  # Here is an issue requesting that the default be removed: https://github.com/bitnami/charts/issues/7279.
+  postgresql:
+    postgresqlPassword: "xinf-2-doHTG._sMJi3*kZgQAabuet"
 
 zookeeper:
   replicaCount: 1

--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -20,31 +20,31 @@ image:
   broker:
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   function:
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   proxy:
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   zookeeper:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   bookkeeper:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   bastion:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
   pulsarSQL:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.0_1.1.1
+    tag: 2.8.0_1.1.3
 
 enableAntiAffinity: false
 # TLS is not included in this example. It is recommended to use TLS to ensure the authenticity and security of tokens.

--- a/helm-chart-sources/pulsar/Chart.yaml
+++ b/helm-chart-sources/pulsar/Chart.yaml
@@ -37,6 +37,6 @@ dependencies:
   repository: https://slamdev.github.io/helm-charts
   condition: envoy.enabled
 - name: keycloak
-  version: 4.0.2
+  version: 4.2.0
   repository: https://charts.bitnami.com/bitnami
   condition: keycloak.enabled

--- a/helm-chart-sources/pulsar/Chart.yaml
+++ b/helm-chart-sources/pulsar/Chart.yaml
@@ -37,6 +37,6 @@ dependencies:
   repository: https://slamdev.github.io/helm-charts
   condition: envoy.enabled
 - name: keycloak
-  version: 4.2.0
+  version: 5.0.1
   repository: https://charts.bitnami.com/bitnami
   condition: keycloak.enabled

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -73,6 +73,14 @@ data:
         server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8964;
       }
 
+      upstream ws-pulsar-proxy {
+      {{- if .Values.enableTls }}
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8000;
+      {{- else }}
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8001;
+      {{- end }}
+      }
+
       {{- if .Values.keycloak.enabled }}
       upstream {{ .Release.Name }}-keycloak {
          {{- if .Values.enableTls }}
@@ -100,9 +108,9 @@ data:
 
             location /ws/ {
               {{- if .Values.enableTls }}
-              proxy_pass https://pulsar-burnell;
+              proxy_pass https://ws-pulsar-proxy;
               {{- else }}
-              proxy_pass http://pulsar-burnell;
+              proxy_pass http://ws-pulsar-proxy;
               {{- end }}
               proxy_http_version 1.1;
               proxy_set_header Upgrade $http_upgrade;

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -75,9 +75,9 @@ data:
 
       upstream ws-pulsar-proxy {
       {{- if .Values.enableTls }}
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8000;
-      {{- else }}
         server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8001;
+      {{- else }}
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8000;
       {{- end }}
       }
 

--- a/helm-chart-sources/pulsar/templates/cert-manager/self-signed-issuer.yaml
+++ b/helm-chart-sources/pulsar/templates/cert-manager/self-signed-issuer.yaml
@@ -70,4 +70,39 @@ spec:
   {{- end }}
   issuerRef:
     name: "{{ template "pulsar.fullname" . }}-ca-issuer"
+## TODO HOW TO MANAGE?
+{{- if .Values.keycloak.enabled }}
+  keystores:
+    jks:
+      create: true
+      # This password is created by the keycloak helm chart
+      passwordSecretRef:
+        name: "{{ template "pulsar.keycloak.fullname" . }}"
+        key: tls-keystore-password
+---
+# Self-signed certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-keycloak-tls"
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: "keycloak-{{ .Values.tlsSecretName }}"
+  dnsNames:
+    - "{{ template "pulsar.keycloak.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "{{ template "pulsar.keycloak.fullname" . }}.{{ .Release.Namespace }}"
+    - "{{ template "pulsar.keycloak.fullname" . }}"
+  {{- if .Values.createCertificates.selfSigned.includeDns }}
+    - "keycloak.{{ .Values.dnsName}}"
+  {{- end }}
+  keystores:
+    jks:
+      create: true
+      # This password is created by the keycloak helm chart
+      passwordSecretRef:
+        name: "{{ template "pulsar.keycloak.fullname" . }}"
+        key: tls-keystore-password
+  issuerRef:
+    name: "{{ template "pulsar.fullname" . }}-ca-issuer"
+{{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/cert-manager/self-signed-issuer.yaml
+++ b/helm-chart-sources/pulsar/templates/cert-manager/self-signed-issuer.yaml
@@ -70,12 +70,12 @@ spec:
   {{- end }}
   issuerRef:
     name: "{{ template "pulsar.fullname" . }}-ca-issuer"
-## TODO HOW TO MANAGE?
 {{- if .Values.keycloak.enabled }}
   keystores:
     jks:
       create: true
       # This password is created by the keycloak helm chart
+      ## TODO It'd probably be better to use a different password here.
       passwordSecretRef:
         name: "{{ template "pulsar.keycloak.fullname" . }}"
         key: tls-keystore-password

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -66,7 +66,7 @@ data:
   tlsEnabled: "true"
   tlsCertificateFilePath: /pulsar/certs/tls.crt
   tlsKeyFilePath: /pulsar/tls-pk8.key
-  {{- if .Values.tls.websocket.enabled }}
+  {{- if or .Values.tls.websocket.enabled .Values.enableTls }}
   brokerClientTlsEnabled: "true"
   {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled}}
   tlsTrustCertsFilePath: /pulsar/certs/ca.crt

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1577,6 +1577,7 @@ pulsarHeartbeat:
 # Deploy Keycloak
 keycloak:
   enabled: false
+  # This block sets up an example Pulsar Realm
   # https://www.keycloak.org/docs/latest/server_admin/#_export_import
   extraStartupArgs: "-Dkeycloak.migration.action=import -Dkeycloak.migration.provider=singleFile -Dkeycloak.migration.file=/realm/pulsar-realm.json -Dkeycloak.migration.strategy=IGNORE_EXISTING"
   extraVolumes: |
@@ -1587,6 +1588,9 @@ keycloak:
     - name: realm-config
       mountPath: "/realm/"
       readOnly: true
+  auth:
+    tls:
+      enabled: false
   # Config specific to this helm chart
   # The realm to use when the Pulsar Admin Console calls Keycloak (this configures nginx)
   # Note that this is the realm in the pre-configured realm that ships with this helm chart

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -352,7 +352,7 @@ image:
   pulsarAdminConsole:
     repository: datastax/pulsar-admin-console
     pullPolicy: IfNotPresent
-    tag: 1.1.0
+    tag: 1.1.1
 
 ## Tiered Storage
 ##


### PR DESCRIPTION
## Motivation

In order for a keycloak deployment to be secure, it is imperative to enable TLS. We provide a plaintext example because can be easier for users to use for testing. This PR adds a TLS example and fixes some minor details.

In the basic TLS example, the helm chart does not use TLS for intra cluster communication. For this example, intra cluster networking for pulsar components is still plaintext, but networking with keycloak is all over TLS.

## Implementation

In order to limit the sharing of intermediate certs, we create two certs using Cert Manager. One for keycloak and one for pulsar components. They share the same root CA generated by Cert Manager (in the self signed certificate use case). As such, mounting the root `ca.crt` into the JVM's truststore is sufficient to establish trust with Keycloak for pulsar components (broker, proxy, admin console, and function worker) that make calls to keycloak.

## Note
Do not merge before https://github.com/bitnami/charts/pull/7149.