### PR TITLE
Pulsar Admin Console (nginx): skip logging query params

### DIFF
--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -47,7 +47,7 @@ data:
               'remote_addr:$remote_addr\t'
               'time_local:$time_local\t'
               'method:$request_method\t'
-              'uri:$request_uri\t'
+              'uri:$uri\t'
               'host:$host\t'
               'status:$status\t'
               'bytes_sent:$body_bytes_sent\t'


### PR DESCRIPTION
This change modifies the nginx log configuration to remove all query params. We do this because the websocket connection passes the user's/client's token as a query param.

Before this change, the logs looked like this:
```
remote_addr:10.240.0.79	time_local:18/Aug/2021:20:20:45 +0000	method:GET	uri:/ws/v2/producer/persistent/public/default/tc1-messages/?token=<TOKEN>	...
remote_addr:10.192.2.1	time_local:18/Aug/2021:20:20:45 +0000	method:GET	uri:/ws/v2/consumer/persistent/public/default/tc1-messages/tc1-sub?token=<TOKEN>&subscriptionType=Exclusive	...
```

And now they look like this:

```
remote_addr:10.240.0.79	time_local:18/Aug/2021:20:19:16 +0000	method:GET	uri:/ws/v2/consumer/persistent/public/default/tc1-messages/tc1-sub	...
remote_addr:10.240.0.78	time_local:18/Aug/2021:20:19:16 +0000	method:GET	uri:/ws/v2/producer/persistent/public/default/tc1-messages/    ...
```

@cdbartholomew - are you good with this change? We could alternatively create a regex that rewrites the `token` param value. However, that leaves us open to other sensitive information that might be in the query parameters.

Source: https://serverfault.com/questions/591546/hide-get-parameters-from-access-logs-on-nginx
