### PR TITLE
Add customProperties field for Function Worker custom configuration

### DIFF
--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -114,8 +114,7 @@ function:
     requests:
       memory: 512Mi
       cpu: 0.3
-#  Cannot use the OpenID provider until this PR is merged https://github.com/apache/pulsar/pull/11468
-#  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+  authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
   configData:
     PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
 

--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -117,6 +117,10 @@ data:
     authenticationProviders: [{{.Values.function.authenticationProviders}}]
     properties:
       tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
+      {{- if .Values.keycloak.enabled }}
+      openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
+      {{- end }}
+{{ toYaml .Values.function.customProperties | indent 6 }}
     clientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
     clientAuthenticationParameters: "file:///pulsar/token-superuser/superuser.jwt"
     superUserRoles:

--- a/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
@@ -37,9 +37,6 @@ data:
   tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
   brokerClientAuthenticationParameters: "file:///pulsar/token-superuser/superuser.jwt"
-  {{- if .Values.keycloak.enabled }}
-  PF_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
-  {{- end }}
   {{- end }}
 {{ toYaml .Values.function.configData | indent 2 }}
   # Workaround for double-quoted values in old values files

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1035,6 +1035,12 @@ function:
 
   authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
 
+  ## When adding custom properties to configure a function worker, the values must be supplied here. Normal config
+  ## is read in to the WorkerConfig fields. Custom configuration (for fields that are not in the WorkerConfig class)
+  ## should be added here. Then, when pulsar calls config.get("my-custom-field"), the fields are in the config's
+  ## properties map. For example, you might use this map to configure the openid-connect plugin.
+  # customProperties: {}
+
   ## Function configmap
   ## templates/function-configmap.yaml
   ##

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1037,7 +1037,7 @@ function:
 
   ## When adding custom properties to configure a function worker, the values must be supplied here. Normal config
   ## is read in to the WorkerConfig fields. Custom configuration (for fields that are not in the WorkerConfig class)
-  ## should be added here. Then, when pulsar calls config.get("my-custom-field"), the fields are in the config's
+  ## should be added here. Then, when pulsar calls config.getProperty("my-custom-field"), the fields are in the config's
   ## properties map. For example, you might use this map to configure the openid-connect plugin.
   # customProperties: {}
 


### PR DESCRIPTION
Configuring the pulsar function worker with custom configuration is a bit different than the rest of pulsar. Custom fields must be supplied as part of the `properties` map. This PR adds that support and updates the keycloak example, which makes use of this custom configuration.

I tested this functionality in two ways. First, I ensured that the function worker comes up and honors the `openIDAllowedTokenIssuers` field. Second, I use `helm template` to verify that the formatting is correct for the `customProperties` map.