### PR TITLE
[Function] Only add custom config when present

### DIFF
--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -120,7 +120,9 @@ data:
       {{- if .Values.keycloak.enabled }}
       openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
       {{- end }}
+      {{- if .Values.function.customProperties }}
 {{ toYaml .Values.function.customProperties | indent 6 }}
+      {{- end }}
     clientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
     clientAuthenticationParameters: "file:///pulsar/token-superuser/superuser.jwt"
     superUserRoles:


### PR DESCRIPTION
When I tested https://github.com/datastax/pulsar-helm-chart/pull/49, I failed to test the case that the value isn't supplied. In that case, the function worker failed to start. This PR addresses that case.