### PR TITLE
Include function worker in CI testing

### DIFF
--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -25,6 +25,7 @@ restartOnConfigMapChange:
   enabled: true
 extra:
   autoRecovery: false
+  function: true
   burnell: true
   pulsarHeartbeat: true
   pulsarAdminConsole: true


### PR DESCRIPTION
Because we are running with `.Values.extras.burnell` set to `true`, we need to also enable the function worker. The function worker sets up the `pulsar/function` namespace. I think this change might increase the speed of our CI testing, as burnell will not open a ton of connections to the test broker.