### PR TITLE
Add KOP Proxy to Luna Streaming Helm Chart

### DIFF
--- a/examples/dev-values-kop-proxy-tls.yaml
+++ b/examples/dev-values-kop-proxy-tls.yaml
@@ -1,0 +1,151 @@
+#
+#  Copyright 2021 DataStax, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+# Please note that this example works only with Luna Streaming 2.8.0.1.1.5+
+
+# Customize the value of kafkaAdvertisedListeners in order to reflect the actual advertised name for your Proxy service
+
+enableAntiAffinity: false
+enableTls: true
+enableTokenAuth: true
+restartOnConfigMapChange:
+  enabled: true
+extra:
+  function: true
+  burnell: true
+  burnellLogCollector: true
+  pulsarHeartbeat: true
+  pulsarAdminConsole: true
+
+cert-manager:
+  enabled: true
+
+createCertificates:
+  selfSigned:
+    enabled: true
+
+zookeeper:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+
+bookkeeper:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  configData:
+    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+
+broker:
+  component: broker
+  service:
+    annotations: {}
+    type: ClusterIP
+    headless: false
+    ports:
+    - name: http
+      port: 8080
+    - name: pulsar
+      port: 6650
+    - name: https
+      port: 8443
+    - name: pulsarssl
+      port: 6651
+    - name: kafkaplaintext
+      port: 9092
+    - name: kafkassl
+      port: 9093
+  replicaCount: 3
+  ledger:
+    defaultEnsembleSize: 1
+    defaultAckQuorum: 1
+    defaultWriteQuorum: 1
+  resources:
+    requests:
+      memory: 200Mi
+      cpu: 0.1
+  configData:
+    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+  kafkaOnPulsarEnabled: true
+  kafkaOnPulsar:    
+    saslAllowedMechanisms: PLAIN
+    brokerEntryMetadataInterceptors: "org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor,org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor"
+
+autoRecovery:
+  enableProvisionContainer: yes
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 0.3
+
+
+function:
+  replicaCount: 1
+  functionReplicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+
+proxy:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  wsResources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+  autoPortAssign:
+    enablePlainTextWithTLS: true
+  service:
+    type: ClusterIP
+    autoPortAssign:
+      enabled: true
+  kafkaOnPulsarEnabled: true
+  kafkaOnPulsar:
+    kafkaListeners: "SASL_PLAINTEXT://0.0.0.0:9092,SASL_SSL://0.0.0.0:9093"
+    kafkaAdvertisedListeners: "SASL_PLAINTEXT://127.0.0.1:9092,SASL_SSL://127.0.0.1:9093"
+    saslAllowedMechanisms: PLAIN
+pulsarAdminConsole:
+  replicaCount: 1
+  service:
+    type: ClusterIP
+grafana: #ASF Helm Chart
+  service:
+    type: ClusterIP
+pulsar_manager:
+  service: #ASF Helm Chart
+    type: ClusterIP
+kube-prometheus-stack:
+  enabled: false
+  prometheusOperator:
+    enabled: false
+  grafana:
+    enabled: false
+    adminPassword: e9JYtk83*4#PM8    

--- a/examples/dev-values-kop-proxy-tls.yaml
+++ b/examples/dev-values-kop-proxy-tls.yaml
@@ -16,9 +16,6 @@
 #
 
 # Please note that this example works only with Luna Streaming 2.8.0.1.1.5+
-
-# Customize the value of kafkaAdvertisedListeners in order to reflect the actual advertised name for your Proxy service
-
 enableAntiAffinity: false
 enableTls: true
 enableTokenAuth: true
@@ -121,9 +118,10 @@ proxy:
       cpu: 0.3
   configData:
     PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
-    PULSARPREFIX_kafkaListeners: "SASL_PLAINTEXT://0.0.0.0:9092,SASL_SSL://0.0.0.0:9093"
-    PULSARPREFIX_kafkaAdvertisedListeners: "SASL_PLAINTEXT://127.0.0.1:9092,SASL_SSL://127.0.0.1:9093"
-    PULSARPREFIX_saslAllowedMechanisms: PLAIN
+    PULSAR_PREFIX_kafkaListeners: "SASL_PLAINTEXT://0.0.0.0:9092,SASL_SSL://0.0.0.0:9093"
+    PULSAR_PREFIX_kafkaAdvertisedListeners: "SASL_PLAINTEXT://127.0.0.1:9092,SASL_SSL://127.0.0.1:9093"
+    PULSAR_PREFIX_saslAllowedMechanisms: PLAIN
+    PULSAR_PREFIX_kafkaProxySuperUserRole: superuser
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:
@@ -132,7 +130,7 @@ proxy:
       enabled: true
   protocolHandlers:
     enabled: true
-    proxyMessagingProtocols: "kafka"
+    protocols: "kafka"
     containerPorts:
       - name: kafkaplaintext
         containerPort: 9092

--- a/examples/dev-values-kop-proxy-tls.yaml
+++ b/examples/dev-values-kop-proxy-tls.yaml
@@ -121,17 +121,32 @@ proxy:
       cpu: 0.3
   configData:
     PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSARPREFIX_kafkaListeners: "SASL_PLAINTEXT://0.0.0.0:9092,SASL_SSL://0.0.0.0:9093"
+    PULSARPREFIX_kafkaAdvertisedListeners: "SASL_PLAINTEXT://127.0.0.1:9092,SASL_SSL://127.0.0.1:9093"
+    PULSARPREFIX_saslAllowedMechanisms: PLAIN
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:
     type: ClusterIP
     autoPortAssign:
       enabled: true
-  kafkaOnPulsarEnabled: true
-  kafkaOnPulsar:
-    kafkaListeners: "SASL_PLAINTEXT://0.0.0.0:9092,SASL_SSL://0.0.0.0:9093"
-    kafkaAdvertisedListeners: "SASL_PLAINTEXT://127.0.0.1:9092,SASL_SSL://127.0.0.1:9093"
-    saslAllowedMechanisms: PLAIN
+  protocolHandlers:
+    enabled: true
+    proxyMessagingProtocols: "kafka"
+    containerPorts:
+      - name: kafkaplaintext
+        containerPort: 9092
+      - name: kafkassl
+        containerPort: 9093
+    servicePorts:
+     - name: kafkaplaintext
+       port: 9092
+       protocol: TCP
+       targetPort: kafkaplaintext
+     - name: kafkassl
+       port: 9093
+       protocol: TCP
+       targetPort: kafkassl      
 pulsarAdminConsole:
   replicaCount: 1
   service:

--- a/examples/dev-values-kop.yaml
+++ b/examples/dev-values-kop.yaml
@@ -133,9 +133,8 @@ broker:
   configData:
     PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
   kafkaOnPulsarEnabled: true
-  kafkaOnPulsar:
-    kafkaListeners: "PLAINTEXT://0.0.0.0:9092"
-    kafkaAdvertisedListeners: "PLAINTEXT://127.0.0.1:19092"
+  kafkaOnPulsar:    
+    saslAllowedMechanisms: PLAIN
     brokerEntryMetadataInterceptors: "org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor,org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor"
 
 # Envoy proxy for Kafka-on-Pulsar

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
@@ -295,6 +295,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        {{- if .Values.broker.kafkaOnPulsarEnabled }}
+        - name: PULSAR_PREFIX_kafkaAdvertisedListeners
+          value: "PLAINTEXT://$(advertisedAddress):9092"
+        {{- end }}
         {{- if .Values.broker.ledger }}
         - name: managedLedgerDefaultAckQuorum
           value: "{{ .Values.broker.ledger.defaultAckQuorum }}"

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
@@ -289,6 +289,14 @@ spec:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}"
         {{- if .Values.brokerSts.ledger }}
         env:
+        - name: advertisedAddress
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- if .Values.broker.kafkaOnPulsarEnabled }}
+        - name: PULSAR_PREFIX_kafkaAdvertisedListeners
+          value: "PLAINTEXT://$(advertisedAddress):9092"
+        {{- end }}
         - name: managedLedgerDefaultAckQuorum
           value: "{{ .Values.brokerSts.ledger.defaultAckQuorum }}"
         - name: managedLedgerDefaultEnsembleSize

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -123,8 +123,6 @@ data:
   PULSAR_GC: {{ .Values.proxy.configData.PULSAR_GC }}
 {{- end }}
 {{- if .Values.proxy.protocolHandlers.enabled }}
-  proxyProtocolHandlerDirectory: "{{ .Values.proxy.protocolHandlers.proxyProtocolHandlerDirectory }}"
-  proxyMessagingProtocols: "{{ .Values.proxy.protocolHandlers.protocols }}"
   PULSAR_PREFIX_proxyProtocolHandlerDirectory: "{{ .Values.proxy.protocolHandlers.proxyProtocolHandlerDirectory }}"
   PULSAR_PREFIX_proxyMessagingProtocols: "{{ .Values.proxy.protocolHandlers.protocols }}"
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -122,3 +122,15 @@ data:
   PULSAR_MEM: {{ .Values.proxy.configData.PULSAR_MEM }}
   PULSAR_GC: {{ .Values.proxy.configData.PULSAR_GC }}
 {{- end }}
+{{- if .Values.proxy.kafkaOnPulsarEnabled }}
+  # enabling Kafka-on-Pulsar
+  proxyProtocolHandlerDirectory: "./proxyprotocols"
+  proxyMessagingProtocols: "kafka"  
+  PULSAR_PREFIX_proxyProtocolHandlerDirectory: "./proxyprotocols"
+  PULSAR_PREFIX_proxyMessagingProtocols: "kafka"  
+  {{- range $key, $val := .Values.proxy.kafkaOnPulsar }}
+  {{ $key }}: {{ $val | quote }}
+  {{ printf "PULSAR_PREFIX_%s" $key }}: {{ $val | quote }}
+  {{- end }}
+  # end of Kafka-on-Pulsar configs
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -122,15 +122,9 @@ data:
   PULSAR_MEM: {{ .Values.proxy.configData.PULSAR_MEM }}
   PULSAR_GC: {{ .Values.proxy.configData.PULSAR_GC }}
 {{- end }}
-{{- if .Values.proxy.kafkaOnPulsarEnabled }}
-  # enabling Kafka-on-Pulsar
-  proxyProtocolHandlerDirectory: "./proxyprotocols"
-  proxyMessagingProtocols: "kafka"  
-  PULSAR_PREFIX_proxyProtocolHandlerDirectory: "./proxyprotocols"
-  PULSAR_PREFIX_proxyMessagingProtocols: "kafka"  
-  {{- range $key, $val := .Values.proxy.kafkaOnPulsar }}
-  {{ $key }}: {{ $val | quote }}
-  {{ printf "PULSAR_PREFIX_%s" $key }}: {{ $val | quote }}
-  {{- end }}
-  # end of Kafka-on-Pulsar configs
+{{- if .Values.proxy.protocolHandlers.enabled }}
+  proxyProtocolHandlerDirectory: "{{ .Values.proxy.protocolHandlers.proxyProtocolHandlerDirectory }}"
+  proxyMessagingProtocols: "{{ .Values.proxy.protocolHandlers.protocols }}"
+  PULSAR_PREFIX_proxyProtocolHandlerDirectory: "{{ .Values.proxy.protocolHandlers.proxyProtocolHandlerDirectory }}"
+  PULSAR_PREFIX_proxyMessagingProtocols: "{{ .Values.proxy.protocolHandlers.protocols }}"
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -260,11 +260,8 @@ spec:
         ports:
         - name: wss
           containerPort: 8001
-        {{- if .Values.proxy.kafkaOnPulsarEnabled }}
-        - name: kafkaplaintext
-          containerPort: 9092
-        - name: kafkassl
-          containerPort: 9093
+        {{- if and .Values.proxy.protocolHandlers.enabled .Values.proxy.protocolHandlers.containerPorts }}
+{{ toYaml .Values.proxy.protocolHandlers.containerPorts | indent 8 }}
         {{- end }}
         volumeMounts:
           - name: health

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -260,6 +260,12 @@ spec:
         ports:
         - name: wss
           containerPort: 8001
+        {{- if .Values.proxy.kafkaOnPulsarEnabled }}
+        - name: kafkaplaintext
+          containerPort: 9092
+        - name: kafkassl
+          containerPort: 9093
+        {{- end }}
         volumeMounts:
           - name: health
             mountPath: /pulsar/health

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-service.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-service.yaml
@@ -47,6 +47,9 @@ spec:
   {{- else }}
 {{ toYaml .Values.proxy.service.ports | indent 2 }}
   {{- end }}
+  {{- if and .Values.proxy.protocolHandlers.enabled .Values.proxy.protocolHandlers.servicePorts }}
+{{ toYaml .Values.proxy.protocolHandlers.servicePorts | indent 2 }}
+  {{- end }}
   selector:
     app: {{ template "pulsar.name" . }}
     release: {{ .Release.Name }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1189,21 +1189,21 @@ proxy:
     ## Ports to open on the proxy container for protocol handler traffic
     ## Kafka on Pulsar is used as an example
     containerPorts: []
-    #- name: kafkaplaintext
-    #  containerPort: 9092
-    #- name: kafkassl
-    #  containerPort: 9093
+    # - name: kafkaplaintext
+    #   containerPort: 9092
+    # - name: kafkassl
+    #   containerPort: 9093
     ## Ports to open on the proxy service for protocol handler traffic
     ## Kafka on Pulsar is used as an example
     servicePorts: []
-    #- name: kafkaplaintext
-    #  port: 9092
-    #  protocol: TCP
-    #  targetPort: kafkaplaintext
-    #- name: kafkassl
-    #  port: 9093
-    #  protocol: TCP
-    #  targetPort: kafkassl
+    # - name: kafkaplaintext
+    #   port: 9092
+    #   protocol: TCP
+    #   targetPort: kafkaplaintext
+    # - name: kafkassl
+    #   port: 9093
+    #   protocol: TCP
+    #   targetPort: kafkassl
   probe:
     enabled: true
     initial: 10

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -768,8 +768,7 @@ broker:
   # https://github.com/datastax/kop
   kafkaOnPulsarEnabled: false
   kafkaOnPulsar:
-    kafkaListeners: "PLAINTEXT://localhost:9092"
-    kafkaAdvertisedListeners: "PLAINTEXT://localhost:9092"
+    kafkaListeners: "PLAINTEXT://0.0.0.0:9092"
     brokerEntryMetadataInterceptors: "org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor,org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor"
 
   webSocketServiceEnabled: false

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1185,7 +1185,7 @@ proxy:
     enabled: false
     proxyProtocolHandlerDirectory: "./proxyprotocols"
     ## Comma separated list of protocols used by the protocol handler
-    proxyMessagingProtocols: ""
+    protocols: ""
     ## Ports to open on the proxy container for protocol handler traffic
     ## Kafka on Pulsar is used as an example
     containerPorts: []

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1178,10 +1178,32 @@ proxy:
   #         values:
   #         - pulsar
   gracePeriod: 60
-  kafkaOnPulsarEnabled: false
-  kafkaOnPulsar:
-    kafkaListeners: "PLAINTEXT://localhost:9092"
-    kafkaAdvertisedListeners: "PLAINTEXT://localhost:9092"
+  ## Protocol handlers can be configured via the configData map located in this
+  ## section of the values file: .Values.proxy.configData
+  ## Some configuration options are provided here to simplify deployment
+  protocolHandlers:
+    enabled: true
+    proxyProtocolHandlerDirectory: "./proxyprotocols"
+    ## Comma separated list of protocols used by the protocol handler
+    proxyMessagingProtocols: ""
+    ## Ports to open on the proxy container for protocol handler traffic
+    ## Kafka on Pulsar is used as an example
+    containerPorts: []
+    #- name: kafkaplaintext
+    #  containerPort: 9092
+    #- name: kafkassl
+    #  containerPort: 9093
+    ## Ports to open on the proxy service for protocol handler traffic
+    ## Kafka on Pulsar is used as an example
+    servicePorts: []
+    #- name: kafkaplaintext
+    #  port: 9092
+    #  protocol: TCP
+    #  targetPort: kafkaplaintext
+    #- name: kafkassl
+    #  port: 9093
+    #  protocol: TCP
+    #  targetPort: kafkassl
   probe:
     enabled: true
     initial: 10
@@ -1289,12 +1311,6 @@ proxy:
     - name: ws
       port: 8000
       protocol: TCP
-    - name: kafkaplaintext
-      port: 9092
-      protocol: TCP
-    - name: kafkassl
-      port: 9093
-      protocol: TCP
 
   # For creating and extra service pointing to the proxy
   extraService:
@@ -1312,12 +1328,6 @@ proxy:
       protocol: TCP
     - name: ws
       port: 8000
-      protocol: TCP
-    - name: kafkaplaintext
-      port: 9092
-      protocol: TCP
-    - name: kafkassl
-      port: 9093
       protocol: TCP
 
   ingress:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1182,7 +1182,7 @@ proxy:
   ## section of the values file: .Values.proxy.configData
   ## Some configuration options are provided here to simplify deployment
   protocolHandlers:
-    enabled: true
+    enabled: false
     proxyProtocolHandlerDirectory: "./proxyprotocols"
     ## Comma separated list of protocols used by the protocol handler
     proxyMessagingProtocols: ""

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1179,6 +1179,10 @@ proxy:
   #         values:
   #         - pulsar
   gracePeriod: 60
+  kafkaOnPulsarEnabled: false
+  kafkaOnPulsar:
+    kafkaListeners: "PLAINTEXT://localhost:9092"
+    kafkaAdvertisedListeners: "PLAINTEXT://localhost:9092"
   probe:
     enabled: true
     initial: 10
@@ -1286,6 +1290,12 @@ proxy:
     - name: ws
       port: 8000
       protocol: TCP
+    - name: kafkaplaintext
+      port: 9092
+      protocol: TCP
+    - name: kafkassl
+      port: 9093
+      protocol: TCP
 
   # For creating and extra service pointing to the proxy
   extraService:
@@ -1303,6 +1313,12 @@ proxy:
       protocol: TCP
     - name: ws
       port: 8000
+      protocol: TCP
+    - name: kafkaplaintext
+      port: 9092
+      protocol: TCP
+    - name: kafkassl
+      port: 9093
       protocol: TCP
 
   ingress:


### PR DESCRIPTION
This is a feature branch for adding support for KOP Proxy in the proxy pod.
Changes:
- add 'proxy.kafkaOnPulsarEnabled' to enable KOP on the Proxy
- configure automatically kafkaAdvertisedListeners on the Broker pods

The KOP proxy works well without Auth and TLS with this change.
I have to add support for those features, then we are good to go

