### PR TITLE
Make proxy protocol handlers more generic

### DIFF
--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -122,15 +122,9 @@ data:
   PULSAR_MEM: {{ .Values.proxy.configData.PULSAR_MEM }}
   PULSAR_GC: {{ .Values.proxy.configData.PULSAR_GC }}
 {{- end }}
-{{- if .Values.proxy.kafkaOnPulsarEnabled }}
-  # enabling Kafka-on-Pulsar
-  proxyProtocolHandlerDirectory: "./proxyprotocols"
-  proxyMessagingProtocols: "kafka"  
-  PULSAR_PREFIX_proxyProtocolHandlerDirectory: "./proxyprotocols"
-  PULSAR_PREFIX_proxyMessagingProtocols: "kafka"  
-  {{- range $key, $val := .Values.proxy.kafkaOnPulsar }}
-  {{ $key }}: {{ $val | quote }}
-  {{ printf "PULSAR_PREFIX_%s" $key }}: {{ $val | quote }}
-  {{- end }}
-  # end of Kafka-on-Pulsar configs
+{{- if .Values.proxy.protocolHandlers.enabled }}
+  proxyProtocolHandlerDirectory: "{{ .Values.proxy.protocolHandlers.proxyProtocolHandlerDirectory }}"
+  proxyMessagingProtocols: "{{ .Values.proxy.protocolHandlers.protocols }}"
+  PULSAR_PREFIX_proxyProtocolHandlerDirectory: "{{ .Values.proxy.protocolHandlers.proxyProtocolHandlerDirectory }}"
+  PULSAR_PREFIX_proxyMessagingProtocols: "{{ .Values.proxy.protocolHandlers.protocols }}"
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -260,11 +260,8 @@ spec:
         ports:
         - name: wss
           containerPort: 8001
-        {{- if .Values.proxy.kafkaOnPulsarEnabled }}
-        - name: kafkaplaintext
-          containerPort: 9092
-        - name: kafkassl
-          containerPort: 9093
+        {{- if and .Values.proxy.protocolHandlers.enabled .Values.proxy.protocolHandlers.containerPorts }}
+{{ toYaml .Values.proxy.protocolHandlers.containerPorts | indent 8 }}
         {{- end }}
         volumeMounts:
           - name: health

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-service.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-service.yaml
@@ -47,6 +47,9 @@ spec:
   {{- else }}
 {{ toYaml .Values.proxy.service.ports | indent 2 }}
   {{- end }}
+  {{- if and .Values.proxy.protocolHandlers.enabled .Values.proxy.protocolHandlers.servicePorts }}
+{{ toYaml .Values.proxy.protocolHandlers.servicePorts | indent 2 }}
+  {{- end }}
   selector:
     app: {{ template "pulsar.name" . }}
     release: {{ .Release.Name }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1189,21 +1189,21 @@ proxy:
     ## Ports to open on the proxy container for protocol handler traffic
     ## Kafka on Pulsar is used as an example
     containerPorts: []
-    #- name: kafkaplaintext
-    #  containerPort: 9092
-    #- name: kafkassl
-    #  containerPort: 9093
+    # - name: kafkaplaintext
+    #   containerPort: 9092
+    # - name: kafkassl
+    #   containerPort: 9093
     ## Ports to open on the proxy service for protocol handler traffic
     ## Kafka on Pulsar is used as an example
     servicePorts: []
-    #- name: kafkaplaintext
-    #  port: 9092
-    #  protocol: TCP
-    #  targetPort: kafkaplaintext
-    #- name: kafkassl
-    #  port: 9093
-    #  protocol: TCP
-    #  targetPort: kafkassl
+    # - name: kafkaplaintext
+    #   port: 9092
+    #   protocol: TCP
+    #   targetPort: kafkaplaintext
+    # - name: kafkassl
+    #   port: 9093
+    #   protocol: TCP
+    #   targetPort: kafkassl
   probe:
     enabled: true
     initial: 10

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1178,10 +1178,32 @@ proxy:
   #         values:
   #         - pulsar
   gracePeriod: 60
-  kafkaOnPulsarEnabled: false
-  kafkaOnPulsar:
-    kafkaListeners: "PLAINTEXT://localhost:9092"
-    kafkaAdvertisedListeners: "PLAINTEXT://localhost:9092"
+  ## Protocol handlers can be configured via the configData map located in this
+  ## section of the values file: .Values.proxy.configData
+  ## Some configuration options are provided here to simplify deployment
+  protocolHandlers:
+    enabled: true
+    proxyProtocolHandlerDirectory: "./proxyprotocols"
+    ## Comma separated list of protocols used by the protocol handler
+    proxyMessagingProtocols: ""
+    ## Ports to open on the proxy container for protocol handler traffic
+    ## Kafka on Pulsar is used as an example
+    containerPorts: []
+    #- name: kafkaplaintext
+    #  containerPort: 9092
+    #- name: kafkassl
+    #  containerPort: 9093
+    ## Ports to open on the proxy service for protocol handler traffic
+    ## Kafka on Pulsar is used as an example
+    servicePorts: []
+    #- name: kafkaplaintext
+    #  port: 9092
+    #  protocol: TCP
+    #  targetPort: kafkaplaintext
+    #- name: kafkassl
+    #  port: 9093
+    #  protocol: TCP
+    #  targetPort: kafkassl
   probe:
     enabled: true
     initial: 10
@@ -1289,12 +1311,6 @@ proxy:
     - name: ws
       port: 8000
       protocol: TCP
-    - name: kafkaplaintext
-      port: 9092
-      protocol: TCP
-    - name: kafkassl
-      port: 9093
-      protocol: TCP
 
   # For creating and extra service pointing to the proxy
   extraService:
@@ -1312,12 +1328,6 @@ proxy:
       protocol: TCP
     - name: ws
       port: 8000
-      protocol: TCP
-    - name: kafkaplaintext
-      port: 9092
-      protocol: TCP
-    - name: kafkassl
-      port: 9093
       protocol: TCP
 
   ingress:


### PR DESCRIPTION
@eolivelli and @cbornet - I created my own branch targeting @eolivelli's branch `impl/kop-proxy-poc` to show some optional changes we could make to make the chart a bit more generic and to follow some recent paradigms that we've been moving towards. In putting this together, I realized that the pattern Enrico followed was created by code introduced by @dlg99. I'd appreciate his input here too. If we go with this paradigm, we might want to update the chart for the broker and brokerSts implementations to bring them into alignment.

My main goal is that if we want to support multiple protocol handlers, we should make sure the helm chart easily manages all of them.

Key changes:
* Make `enabled` a field within the `protocolHandlers` map. There are cases where we used the `protocolHandlersEnabled` paradigm, but I think the current practice is to make `enabled` a field in the map, as I have done here.
* Make the `proxyProtocolHandlerDirectory` and `proxyMessagingProtocols` configurable.
* Make a note that users can configure the proxy with `.Values.proxy.configData`. On the other hand, it might be better to introduce a field like `.Values.proxy.protocolHandlers.configData` so that all configuration of proxy handlers can be in the same place. Technically, nothing would prevent a user from putting configuration in the other config data location.
* Put the proxy `containerPorts` and `servicePorts` under the `.Values.proxy.protocolHandlers` map. The other implementation was absolutely valid, but my change ensures that container ports and service ports can be configured in similar locations within a `values.yaml` file. This would improve readability.

I welcome any and all feedback for my changes. I quickly put this together and am still trying to decide what our norms should be. I don't think we have best practices for our helm chart yet.

Question:
* Why do we have configurations getting set with no prefix and with `PULSAR_PREFIX_`? My understanding was that by setting something with the prefix `PULSAR_PREFIX_`, we wouldn't need to set it with no prefix, since the python script used to get env vars and add them to the `.conf` files will map them to the right field. I haven't verified the behavior though. It'd be good to only map a field once.