### PR TITLE
GCP secret auto creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ helm install pulsar -f dev-values-tls.yaml datastax-pulsar/pulsar
 
 ## Tiered Storage
 
-Tiered storage (offload to blob storage) can be configured in the `storageOffload` section of the `values.yaml` file. Instructions for AWS S3 and Google Cloud Storage are provided in the file.
+Tiered storage (offload to blob storage) can be configured in the `storageOffload` section of the `values.yaml` file. Instructions for AWS S3, Google Cloud Storage and Azure are provided in the file.
 
 In addition you can configure any S3 compatible storage. There is explicit support for [Tardigrade](https://tardigrade.io), which is a provider of secure, decentralized storage. You can enable the Tardigarde S3 gateway in the `extra` configuration. The instructions for configuring the gateway are provided in the `tardigrade` section of the `values.yaml` file.
 

--- a/helm-chart-sources/pulsar/ci-archive/gcp-storage-no-test.yaml
+++ b/helm-chart-sources/pulsar/ci-archive/gcp-storage-no-test.yaml
@@ -32,6 +32,7 @@ storageOffload:
   driver: google-cloud-storage
   gcsServiceAccountSecret: pulsar-gcp-sa-secret # pragma: allowlist secret
   gcsServiceAccountJsonFile: account-223201-f12856532197.json
+  gcsServiceAccountJsonFileContent: <must be passed from env variable in Helm command line> # this should be a base64-encoded string $(cat <gcsServiceAccountJsonFile> | base64)
   bucket: kesque-tired-storage-test
   region: us
   # General Storage Offload Setting

--- a/helm-chart-sources/pulsar/templates/utils/gcp-secret.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/gcp-secret.yaml
@@ -1,0 +1,34 @@
+#
+#  Copyright 2021 DataStax, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+{{- if eq .Values.storageOffload.driver "google-cloud-storage"}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{.Values.storageOffload.gcsServiceAccountSecret}}"
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component:  {{ .Values.broker.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+type: Opaque
+data:
+  {{ .Values.storageOffload.gcsServiceAccountJsonFile }}: {{ .Values.storageOffload.gcsServiceAccountJsonFileContent }}
+---
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/utils/gcp-secret.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/gcp-secret.yaml
@@ -15,7 +15,7 @@
 #
 #
 
-{{- if eq .Values.storageOffload.driver "google-cloud-storage"}}
+{{- if eq .Values.storageOffload.driver "google-cloud-storage" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm-chart-sources/pulsar/templates/utils/gcp-secret.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/gcp-secret.yaml
@@ -15,7 +15,7 @@
 #
 #
 
-{{- if eq .Values.storageOffload.driver "google-cloud-storage" }}
+{{- if eq "{{.Values.storageOffload.driver}}" "google-cloud-storage" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -414,8 +414,8 @@ storageOffload: {}
   ##      * Set storageOffload.gcsServiceAccountJsonFileContent to the
   ##        base64-encoded content of the JSON file:
   ##            helm install pulsar \
-  ##	            --set storageOffload.gcsServiceAccountJsonFile=account-223201-f12856532197.json \
-  ##	            --set storageOffload.gcsServiceAccountJsonFileContent=$(cat account-223201-f12856532197.json | base64) .
+  ##            --set storageOffload.gcsServiceAccountJsonFile=account-223201-f12856532197.json \
+  ##            --set storageOffload.gcsServiceAccountJsonFileContent=$(cat account-223201-f12856532197.json | base64) .
   ##        This method is totally equivalent to the previous one.
   ##         In fact, it would generate the same secret.
   # driver: google-cloud-storage

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -405,11 +405,19 @@ storageOffload: {}
   ## 4. Give the service account permission to access the bucket. For example,
   ##    the "Storage Object Admin" role.
   ## 5. Create a key for the service account and save it as a JSON file.
-  ## 6. Save the JSON file in a secret:
-  ##       kubectl create secret generic pulsar-gcp-sa-secret \
-  ##          --from-file=account-223201-f12856532197.json \
-  ##          --namespace pulsar
-  ##
+  ## 6. Either of the two steps below:
+  ##     * Save the JSON file in a k8s secret:
+  ##          kubectl create secret generic pulsar-gcp-sa-secret \
+  ##             --from-file=account-223201-f12856532197.json \
+  ##             --namespace pulsar
+  ##      OR
+  ##      * Set storageOffload.gcsServiceAccountJsonFileContent to the
+  ##        base64-encoded content of the JSON file:
+  ##            helm install pulsar \
+  ##	            --set storageOffload.gcsServiceAccountJsonFile=account-223201-f12856532197.json \
+  ##	            --set storageOffload.gcsServiceAccountJsonFileContent=$(cat account-223201-f12856532197.json | base64) .
+  ##        This method is totally equivalent to the previous one.
+  ##         In fact, it would generate the same secret.
   # driver: google-cloud-storage
   # gcsServiceAccountSecret: pulsar-gcp-sa-secret # pragma: allowlist secret
   # gcsServiceAccountJsonFile: account-223201-f12856532197.json


### PR DESCRIPTION
Initialising a k8s secret storing an injected GCP service account secret. This addition automates the secure provision of GCP credentials, which are passed to helm via `--set`. 