### PR TITLE
Feature/offload/azure

### DIFF
--- a/helm-chart-sources/pulsar/ci-archive/azure-no-test.yaml
+++ b/helm-chart-sources/pulsar/ci-archive/azure-no-test.yaml
@@ -1,0 +1,82 @@
+#
+#  Copyright 2021 DataStax, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+persistence: false
+enableTests: true
+extra:
+  autoRecovery: false
+  bastion: true
+  proxy: false
+  pulsarHeartbeat: false
+
+image:
+  broker:
+    # If using tiered storage, use pulsar-all image for broker
+    repository: datastax/pulsar-all
+
+storageOffload:
+
+  bucket: kesque-helm-chart-ci-test
+  region: us-east-1
+  maxBlockSizeInBytes: "6400000"
+  readBufferSizeInBytes: "100000"
+  ## The following are default values for the cluster. They can be changed
+  ## on each namespace.
+  managedLedgerOffloadDeletionLagMs: "1000"
+  managedLedgerOffloadAutoTriggerSizeThresholdBytes: "1000"
+
+  # For Azure
+  # ======
+  # You must create a storage account
+  #
+  driver: azureblob
+  storageAccount: <must be passed from env variable in Helm command line>
+  storageAccountKey: <must be passed from env variable in Helm command line> # pragma: allowlist secret
+  ## For s3 compatible services, need to specify the endpoint but
+  ## not needed for AWS
+  #serviceEndpoint: http://127.0.0.1:7777
+
+zookeeper:
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "\"-Xms512m -Xmx512m -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:+DisableExplicitGC -XX:+PerfDisableSharedMem -Dzookeeper.forceSync=no\""
+
+bookkeeper:
+  replicaCount: 2
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  configData:
+    BOOKIE_MEM: "-Xms512m -Xmx512m -XX:MaxDirectMemorySize=512m -XX:+ExitOnOutOfMemoryError"
+    BOOKIE_GC: "\"-XX:+UseG1GC -XX:MaxGCPauseMillis=10\""
+
+broker:
+  component: broker
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 1000Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "\"-Xms512m -Xmx1000m -XX:MaxDirectMemorySize=1000m -XX:+ExitOnOutOfMemoryError\""
+    managedLedgerMaxEntriesPerLedger: "5000"
+    managedLedgerMinLedgerRolloverTimeMinutes: "1"
+    managedLedgerMaxLedgerRolloverTimeMinutes: "2"

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -210,6 +210,29 @@ data:
   gcsManagedLedgerOffloadReadBufferSizeInBytes: "{{ .Values.storageOffload.readBufferSizeInBytes }}"
   {{- end }}
 {{- end }}
+{{- if eq .Values.storageOffload.driver "azureblob" }}
+  managedLedgerOffloadDriver: "{{ .Values.storageOffload.driver }}"
+  managedLedgerOffloadBucket: "{{ .Values.storageOffload.bucket }}"
+  # workaround to inject it in the broker.conf (problem: gets injected also in client.conf)
+  PULSAR_PREFIX_managedLedgerOffloadBucket: "{{ .Values.storageOffload.bucket }}"
+  AZURE_STORAGE_ACCOUNT: "{{ .Values.storageOffload.storageAccount }}"
+  AZURE_STORAGE_ACCESS_KEY: "{{ .Values.storageOffload.storageAccountKey }}"
+  {{- if .Values.storageOffload.managedLedgerOffloadAutoTriggerSizeThresholdBytes }}
+  # Pre 2.6.0 value
+  managedLedgerOffloadAutoTriggerSizeThresholdBytes: "{{ .Values.storageOffload.managedLedgerOffloadAutoTriggerSizeThresholdBytes }}"
+  # Post 2.6.0 value
+  PULSAR_PREFIX_managedLedgerOffloadThresholdInBytes: "{{ .Values.storageOffload.managedLedgerOffloadAutoTriggerSizeThresholdBytes }}"
+  {{- end }}
+  {{- if .Values.storageOffload.managedLedgerOffloadDeletionLagMs }}
+  # Pre 2.6.0 value
+  managedLedgerOffloadDeletionLagMs: "{{ .Values.storageOffload.managedLedgerOffloadDeletionLagMs }}"
+  # Post 2.6.0 value
+  PULSAR_PREFIX_managedLedgerOffloadDeletionLagInMillis: "{{ .Values.storageOffload.managedLedgerOffloadDeletionLagMs }}"
+  {{- end }}
+  {{- if .Values.storageOffload.maxBlockSizeInBytes }}
+  managedLedgerOffloadMaxBlockSizeInBytes: "{{ .Values.storageOffload.maxBlockSizeInBytes }}"
+  {{- end }}
+{{- end }}
 {{- end }}
 {{ toYaml .Values.broker.configData | indent 2 }}
   # Workaround for double-quoted values in old values files

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -394,6 +394,15 @@ storageOffload: {}
   #
   # driver: aws-s3
 
+  # For Azure Blob
+  # =================
+  # Need to create an Azure storage account and a blob containter (bucket)
+  # To retrieve key, see https://docs.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal#code-try-1
+  #
+  # driver: azureblob
+  # storageAccount: <account name>
+  # storageAccountKey: <account key>
+
   ## For Google Cloud Storage
   ## ====================
   ## You must create a service account that has access to the objects in GCP buckets


### PR DESCRIPTION
Integrating azure offload by adding an if branch in the `broker-configmap`. 

Note: I have also added the workaround below in order to solve smth which looks like a pulsar configuration issue (`managedLedgerOffloadBucket` is apparently missing in [broker.conf](https://github.com/apache/pulsar/blob/master/conf/broker.conf)). 

```
# workaround to inject it in the broker.conf (problem: gets injected also in client.conf)
PULSAR_PREFIX_managedLedgerOffloadBucket: "{{ .Values.storageOffload.bucket }}"
```

This should be probably removed after the actual issue on pulsar has been fixed.