### PR TITLE
GCP secret: removing double quotes 

### DIFF
--- a/helm-chart-sources/pulsar/templates/utils/gcp-secret.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/gcp-secret.yaml
@@ -15,7 +15,7 @@
 #
 #
 
-{{- if eq "{{.Values.storageOffload.driver}}" "google-cloud-storage" }}
+{{- if eq .Values.storageOffload.driver "google-cloud-storage" }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -357,7 +357,8 @@ image:
 ## Tiered Storage
 ##
 
-storageOffload: {}
+storageOffload:
+  driver: ""
   ## General
   ## =======
   # bucket: <bucket>


### PR DESCRIPTION
After removing the double quotes the gcp-service-account secret gets rendered.