### PR TITLE
set max timeout for liveness probe for broker and proxy

### DIFF
--- a/helm-chart-sources/pulsar/templates/utils/health-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/health-configmap.yaml
@@ -30,15 +30,15 @@ data:
   proxy_health_check.sh: |
     #!/bin/bash
     {{- if .Values.enableTokenAuth }}
-    curl -s --connect-timeout 2 --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/metrics/ > /dev/null
+    curl -s --connect-timeout 2 --max-time 4 --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/metrics/ > /dev/null
     {{- else }}
-    curl -s --connect-timeout 2 --fail http://localhost:8080/metrics/ > /dev/null
+    curl -s --connect-timeout 2 --max-time 4 --fail http://localhost:8080/metrics/ > /dev/null
     {{- end }}
 
   broker_health_check.sh: |
     #!/bin/bash
     {{- if .Values.enableTokenAuth }}
-    curl -s --connect-timeout 2 --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/admin/v2/brokers/health
+    curl -s --connect-timeout 2 --max-time 4 --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/admin/v2/brokers/health
     {{- else }}
-    curl -s --connect-timeout 2 --fail http://localhost:8080/admin/v2/brokers/health
+    curl -s --connect-timeout 2 --max-time 4 --fail http://localhost:8080/admin/v2/brokers/health
     {{- end }}


### PR DESCRIPTION
We have seen the healthcheck does not detect the problem that the actual healthcheck topic even failed to be created. So I think we should enforce the max timeout on the health check to restart the broker at Astra Streaming

The two timeouts are described at

https://unix.stackexchange.com/questions/94604/does-curl-have-a-timeout/94612