### PR TITLE
Explicitly specify machine image for CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,8 @@ jobs:
           command: ct lint --config tests/ct.yaml
 
   install-charts:
-    machine: true
+    machine:
+      image: ubuntu-2004:202107-02
     steps:
       - checkout
       - run:
@@ -27,7 +28,8 @@ jobs:
           no_output_timeout: 1h
 
   release-charts:
-    machine: true
+    machine:
+      image: ubuntu-2004:202107-02
     steps:
       - checkout
       - add_ssh_keys:


### PR DESCRIPTION
Our CI pipeline broke because we're using an old base image with an expired root ca cert. This PR should fix the underlying issue.

Here is the Circle CI documentation I'm following: https://circleci.com/docs/2.0/configuration-reference/#available-machine-images.

Here are the logs showing this error:

```
Running ct container...
Unable to find image 'quay.io/helmpack/chart-testing:latest' locally
latest: Pulling from helmpack/chart-testing
<docker pull stats omitted for brevity>
462901137c82: Pull complete 
Digest: sha256:7d66a4ff8803fd31b12e5de66cebdb3cb68a6139be8ecc90592c0208550371c1
Status: Downloaded newer image for quay.io/helmpack/chart-testing:latest
034dc4d5622060adb8d839b4492dd93d19e42187bef54c8d6e5f677fd3457d37

Installing kind...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (60) SSL certificate problem: certificate has expired
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
Removing ct container...
Done!

Exited with code exit status 60
```