### PR TITLE
Add support for reinitializing the cluster Pulsar metadata by passing --set initialize=true

### DIFF
--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
@@ -15,7 +15,7 @@
 #
 #
 
-{{- if .Release.IsInstall }}
+{{- if or .Release.IsInstall .Values.initialize }}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
For testing purposes, I'm deleting all state in an existing cluster
```
kubectl -n pulsar delete sts -l 'component in (broker,bookkeeper,zookeeper)' --wait=true --force
kubectl -n pulsar delete pods -l 'component in (broker,bookkeeper,zookeeper)' --wait=true --force
kubectl -n pulsar delete pvc -l 'component in (bookkeeper,zookeeper)' --wait=true
```

The problem is that in redeploying the helm chart without removing the installation, it's not possible to re-create a job to initialize the Pulsar Zookeeper metadata. This PR makes `--set initialize=true` create the job for initializing Pulsar Zookeeper metadata.