### PR TITLE
Allow configuring liveness and readiness probe timeouts

### DIFF
--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -180,12 +180,14 @@ spec:
             port: 8000
           initialDelaySeconds: {{ .Values.bookkeeper.probe.initial }}
           periodSeconds:  {{ .Values.bookkeeper.probe.period }}
+          timeoutSeconds:  {{ .Values.bookkeeper.probe.timeout }}
         livenessProbe:
           httpGet:
             path: /api/v1/bookie/is_ready
             port: 8000
           initialDelaySeconds: {{ .Values.bookkeeper.probe.initial }}
           periodSeconds:  {{ .Values.bookkeeper.probe.period }}
+          timeoutSeconds:  {{ .Values.bookkeeper.probe.timeout }}
         {{- end }}
       {{- if .Values.bookkeeper.resources }}
         resources:

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
@@ -218,12 +218,14 @@ spec:
             - "/pulsar/health/broker_health_check.sh"
           initialDelaySeconds: {{ .Values.broker.probe.initial }}
           periodSeconds:  {{ .Values.broker.probe.period }}
+          timeoutSeconds:  {{ .Values.broker.probe.timeout }}
         livenessProbe:
           exec:
             command:
             - "/pulsar/health/broker_health_check.sh"
           initialDelaySeconds: {{ .Values.broker.probe.initial }}
           periodSeconds: {{ .Values.broker.probe.period }}
+          timeoutSeconds: {{ .Values.broker.probe.timeout }}
         {{- end }}
       {{- if .Values.broker.resources }}
         resources:

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
@@ -215,12 +215,14 @@ spec:
             - "/pulsar/health/broker_health_check.sh"
           initialDelaySeconds: {{ .Values.brokerSts.probe.initial }}
           periodSeconds:  {{ .Values.brokerSts.probe.period }}
+          timeoutSeconds:  {{ .Values.brokerSts.probe.timeout }}
         livenessProbe:
           exec:
             command:
             - "/pulsar/health/broker_health_check.sh"
           initialDelaySeconds: {{ .Values.brokerSts.probe.initial }}
           periodSeconds: {{ .Values.broker.probe.period }}
+          timeoutSeconds: {{ .Values.broker.probe.timeout }}
         {{- end }}
       {{- if .Values.brokerSts.resources }}
         resources:

--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -200,7 +200,8 @@ spec:
             path: {{ .Values.function.probe.metricsPath | default "/metrics" }}
             port: {{ .Values.function.probe.port }}
           initialDelaySeconds: {{ .Values.function.probe.initial }}
-          timeoutSeconds: {{ .Values.function.probe.period }}
+          periodSeconds:  {{ .Values.function.probe.period }}
+          timeoutSeconds:  {{ .Values.function.probe.timeout }}
         {{- end }}
         {{- if .Values.function.resources }}
         resources:

--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -194,6 +194,7 @@ spec:
             port: {{ .Values.function.probe.port }}
           initialDelaySeconds: {{ .Values.function.probe.initial }}
           periodSeconds:  {{ .Values.function.probe.period }}
+          timeoutSeconds:  {{ .Values.function.probe.timeout }}
         livenessProbe:
           httpGet:
             path: {{ .Values.function.probe.metricsPath | default "/metrics" }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -232,12 +232,14 @@ spec:
             - "/pulsar/health/proxy_health_check.sh"
           initialDelaySeconds: {{ .Values.proxy.probe.initial }}
           periodSeconds:  {{ .Values.proxy.probe.period }}
+          timeoutSeconds:  {{ .Values.proxy.probe.timeout }}
         livenessProbe:
           exec:
             command:
             - "/pulsar/health/proxy_health_check.sh"
           initialDelaySeconds: {{ .Values.proxy.probe.initial }}
           periodSeconds: {{ .Values.proxy.probe.period }}
+          timeoutSeconds: {{ .Values.proxy.probe.timeout }}
         {{- end }}
       {{- if .Values.proxy.resources }}
         resources:

--- a/helm-chart-sources/pulsar/templates/utils/health-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/health-configmap.yaml
@@ -30,15 +30,15 @@ data:
   proxy_health_check.sh: |
     #!/bin/bash
     {{- if .Values.enableTokenAuth }}
-    curl -s --connect-timeout 2 --max-time 4 --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/metrics/ > /dev/null
+    curl -s --connect-timeout 2 --max-time {{ .Values.proxy.probe.timeout }} --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/metrics/ > /dev/null
     {{- else }}
-    curl -s --connect-timeout 2 --max-time 4 --fail http://localhost:8080/metrics/ > /dev/null
+    curl -s --connect-timeout 2 --max-time {{ .Values.proxy.probe.timeout }} --fail http://localhost:8080/metrics/ > /dev/null
     {{- end }}
 
   broker_health_check.sh: |
     #!/bin/bash
     {{- if .Values.enableTokenAuth }}
-    curl -s --connect-timeout 2 --max-time 4 --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/admin/v2/brokers/health
+    curl -s --connect-timeout 2 --max-time {{ .Values.broker.probe.timeout }} --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/admin/v2/brokers/health
     {{- else }}
-    curl -s --connect-timeout 2 --max-time 4 --fail http://localhost:8080/admin/v2/brokers/health
+    curl -s --connect-timeout 2 --max-time {{ .Values.broker.probe.timeout }} --fail http://localhost:8080/admin/v2/brokers/health
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/utils/health-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/health-configmap.yaml
@@ -30,15 +30,15 @@ data:
   proxy_health_check.sh: |
     #!/bin/bash
     {{- if .Values.enableTokenAuth }}
-    curl -s --connect-timeout 2 --max-time {{ .Values.proxy.probe.timeout }} --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/metrics/ > /dev/null
+    curl -s --max-time {{ .Values.proxy.probe.timeout }} --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/metrics/ > /dev/null
     {{- else }}
-    curl -s --connect-timeout 2 --max-time {{ .Values.proxy.probe.timeout }} --fail http://localhost:8080/metrics/ > /dev/null
+    curl -s --max-time {{ .Values.proxy.probe.timeout }} --fail http://localhost:8080/metrics/ > /dev/null
     {{- end }}
 
   broker_health_check.sh: |
     #!/bin/bash
     {{- if .Values.enableTokenAuth }}
-    curl -s --connect-timeout 2 --max-time {{ .Values.broker.probe.timeout }} --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/admin/v2/brokers/health
+    curl -s --max-time {{ .Values.broker.probe.timeout }} --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:8080/admin/v2/brokers/health
     {{- else }}
-    curl -s --connect-timeout 2 --max-time {{ .Values.broker.probe.timeout }} --fail http://localhost:8080/admin/v2/brokers/health
+    curl -s --max-time {{ .Values.broker.probe.timeout }} --fail http://localhost:8080/admin/v2/brokers/health
     {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-statefulset.yaml
@@ -155,13 +155,15 @@ spec:
             command:
             - "bin/pulsar-zookeeper-ruok.sh"
           initialDelaySeconds: {{ .Values.zookeepernp.probe.initial }}
-          timeoutSeconds: {{ .Values.zookeepernp.probe.period }}
+          periodSeconds: {{ .Values.zookeepernp.probe.period }}
+          timeoutSeconds: {{ .Values.zookeepernp.probe.timeout }}
         livenessProbe:
           exec:
             command:
             - "bin/pulsar-zookeeper-ruok.sh"
           initialDelaySeconds: {{ .Values.zookeepernp.probe.initial }}
-          timeoutSeconds: {{ .Values.zookeepernp.probe.period }}
+          periodSeconds: {{ .Values.zookeepernp.probe.period }}
+          timeoutSeconds: {{ .Values.zookeepernp.probe.timeout }}
         {{- end }}
         volumeMounts:
         {{- if and .Values.enableTls .Values.tls.zookeeper.enabled}}

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -176,13 +176,15 @@ spec:
             command:
             - "bin/pulsar-zookeeper-ruok.sh"
           initialDelaySeconds: {{ .Values.zookeeper.probe.initial }}
-          timeoutSeconds: {{ .Values.zookeeper.probe.period }}
+          periodSeconds: {{ .Values.zookeeper.probe.period }}
+          timeoutSeconds: {{ .Values.zookeeper.probe.timeout }}
         livenessProbe:
           exec:
             command:
             - "bin/pulsar-zookeeper-ruok.sh"
           initialDelaySeconds: {{ .Values.zookeeper.probe.initial }}
-          timeoutSeconds: {{ .Values.zookeeper.probe.period }}
+          periodSeconds: {{ .Values.zookeeper.probe.period }}
+          timeoutSeconds: {{ .Values.zookeeper.probe.timeout }}
         {{- end }}
         volumeMounts:
         {{- if and .Values.enableTls .Values.tls.zookeeper.enabled}}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -461,6 +461,7 @@ zookeeper:
     enabled: true
     initial: 10
     period: 30
+    timeout: 5
   resources:
     requests:
       memory: 1Gi
@@ -550,6 +551,7 @@ zookeepernp:
     enabled: true
     initial: 10
     period: 30
+    timeout: 5
   resources:
     requests:
       memory: 1Gi

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -629,6 +629,7 @@ bookkeeper:
     port: 3181
     initial: 10
     period: 30
+    timeout: 5
   gracePeriod: 60
   resources:
     requests:
@@ -797,6 +798,7 @@ broker:
     port: 8080
     initial: 10
     period: 30
+    timeout: 5
   resources:
     requests:
       memory: 2Gi
@@ -907,6 +909,7 @@ brokerSts:
     port: 8080
     initial: 10
     period: 30
+    timeout: 5
   resources:
     requests:
       memory: 2Gi
@@ -986,6 +989,7 @@ function:
     port: 6750
     initial: 10
     period: 30
+    timeout: 5
   # Only the process runtime has been tested with this chart
   runtime: "process"
   k8sMinResources:
@@ -1229,6 +1233,7 @@ proxy:
     enabled: true
     initial: 10
     period: 30
+    timeout: 5
   # Resources for the main Pulsar proxy
   resources:
     requests:


### PR DESCRIPTION
Fixes #73 

- Makes the timeoutSeconds configurable for probes and sets the default to 5 seconds
- Also fix inconsistency in Zookeeper probes where the value for periodSeconds was used for timeoutSeconds.