### PR TITLE
Reduce CI memory usage

### DIFF
--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -40,7 +40,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms64m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "\"-Xms64m -Xmx128m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
 
 bookkeeper:
   replicaCount: 1
@@ -49,7 +49,7 @@ bookkeeper:
       memory: 400Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "-Xms64m -Xmx512m -XX:MaxDirectMemorySize=256m -XX:+ExitOnOutOfMemoryError"
+    BOOKIE_MEM: "-Xms64m -Xmx256m -XX:MaxDirectMemorySize=256m -XX:+ExitOnOutOfMemoryError"
     BOOKIE_GC: "-XX:+UseG1GC -XX:MaxGCPauseMillis=10"
 
 broker:
@@ -64,7 +64,7 @@ broker:
       memory: 400Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "-Xms64m -Xmx400m -XX:MaxDirectMemorySize=256m -XX:+ExitOnOutOfMemoryError"
+    PULSAR_MEM: "-Xms64m -Xmx256m -XX:MaxDirectMemorySize=256m -XX:+ExitOnOutOfMemoryError"
 
 function:
   replicaCount: 1
@@ -74,7 +74,7 @@ function:
       memory: 400Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "-Xms64m -Xmx400m -XX:MaxDirectMemorySize=256m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem"
+    PULSAR_MEM: "-Xms64m -Xmx256m -XX:MaxDirectMemorySize=256m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem"
 
 proxy:
   replicaCount: 1
@@ -87,7 +87,7 @@ proxy:
       memory: 400Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms64m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "\"-Xms64m -Xmx64m -XX:MaxDirectMemorySize=64m\""
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:

--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -59,6 +59,7 @@ bookkeeper:
   configData:
     BOOKIE_MEM: "-Xms64m -Xmx256m -XX:MaxDirectMemorySize=256m -XX:+ExitOnOutOfMemoryError"
     BOOKIE_GC: "-XX:+UseG1GC -XX:MaxGCPauseMillis=10"
+    diskUsageThreshold: "0.99"
 
 broker:
   component: broker

--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -40,7 +40,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms200m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "\"-Xms64m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
 
 bookkeeper:
   replicaCount: 1
@@ -49,7 +49,7 @@ bookkeeper:
       memory: 400Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "-Xms256m -Xmx512m -XX:MaxDirectMemorySize=512m -XX:+ExitOnOutOfMemoryError"
+    BOOKIE_MEM: "-Xms64m -Xmx512m -XX:MaxDirectMemorySize=512m -XX:+ExitOnOutOfMemoryError"
     BOOKIE_GC: "-XX:+UseG1GC -XX:MaxGCPauseMillis=10"
 
 broker:
@@ -64,7 +64,7 @@ broker:
       memory: 400Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "-Xms256m -Xmx400m -XX:MaxDirectMemorySize=400m -XX:+ExitOnOutOfMemoryError"
+    PULSAR_MEM: "-Xms64m -Xmx400m -XX:MaxDirectMemorySize=400m -XX:+ExitOnOutOfMemoryError"
 
 function:
   replicaCount: 1
@@ -74,7 +74,7 @@ function:
       memory: 400Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "-Xms256m -Xmx400m -XX:MaxDirectMemorySize=400m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem"
+    PULSAR_MEM: "-Xms64m -Xmx400m -XX:MaxDirectMemorySize=400m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem"
 
 proxy:
   replicaCount: 1
@@ -87,7 +87,7 @@ proxy:
       memory: 400Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "\"-Xms64m -Xmx400m -XX:MaxDirectMemorySize=112m\""
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:

--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -49,7 +49,7 @@ bookkeeper:
       memory: 400Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "-Xms64m -Xmx512m -XX:MaxDirectMemorySize=512m -XX:+ExitOnOutOfMemoryError"
+    BOOKIE_MEM: "-Xms64m -Xmx512m -XX:MaxDirectMemorySize=256m -XX:+ExitOnOutOfMemoryError"
     BOOKIE_GC: "-XX:+UseG1GC -XX:MaxGCPauseMillis=10"
 
 broker:
@@ -64,7 +64,7 @@ broker:
       memory: 400Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "-Xms64m -Xmx400m -XX:MaxDirectMemorySize=400m -XX:+ExitOnOutOfMemoryError"
+    PULSAR_MEM: "-Xms64m -Xmx400m -XX:MaxDirectMemorySize=256m -XX:+ExitOnOutOfMemoryError"
 
 function:
   replicaCount: 1
@@ -74,7 +74,7 @@ function:
       memory: 400Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "-Xms64m -Xmx400m -XX:MaxDirectMemorySize=400m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem"
+    PULSAR_MEM: "-Xms64m -Xmx400m -XX:MaxDirectMemorySize=256m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem"
 
 proxy:
   replicaCount: 1

--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -38,7 +38,7 @@ zookeeper:
   resources:
     requests:
       memory: 300Mi
-      cpu: 0.3
+      cpu: 100m
   configData:
     PULSAR_MEM: "\"-Xms64m -Xmx128m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
 
@@ -47,7 +47,7 @@ bookkeeper:
   resources:
     requests:
       memory: 400Mi
-      cpu: 0.3
+      cpu: 100m
   configData:
     BOOKIE_MEM: "-Xms64m -Xmx256m -XX:MaxDirectMemorySize=256m -XX:+ExitOnOutOfMemoryError"
     BOOKIE_GC: "-XX:+UseG1GC -XX:MaxGCPauseMillis=10"
@@ -62,7 +62,7 @@ broker:
   resources:
     requests:
       memory: 400Mi
-      cpu: 0.3
+      cpu: 100m
   configData:
     PULSAR_MEM: "-Xms64m -Xmx256m -XX:MaxDirectMemorySize=256m -XX:+ExitOnOutOfMemoryError"
 
@@ -72,7 +72,7 @@ function:
   resources:
     requests:
       memory: 400Mi
-      cpu: 0.3
+      cpu: 100m
   configData:
     PULSAR_MEM: "-Xms64m -Xmx256m -XX:MaxDirectMemorySize=256m -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ParallelRefProcEnabled -XX:+DisableExplicitGC -XX:+ExitOnOutOfMemoryError -XX:+PerfDisableSharedMem"
 
@@ -81,11 +81,11 @@ proxy:
   resources:
     requests:
       memory: 400Mi
-      cpu: 0.3
+      cpu: 100m
   wsResources:
     requests:
       memory: 400Mi
-      cpu: 0.3
+      cpu: 100m
   configData:
     PULSAR_MEM: "\"-Xms64m -Xmx64m -XX:MaxDirectMemorySize=64m\""
   autoPortAssign:

--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -30,6 +30,14 @@ extra:
   pulsarHeartbeat: true
   pulsarAdminConsole: true
 
+# After https://github.com/apache/pulsar/pull/9413 Pulsar seems to load
+# all connector classes to memory. This causes OOM at OS level (error code 143)
+# Mitigate the issue by using a container image without the connectors.
+image:
+  function:
+    repository: datastax/lunastreaming
+
+
 autoRecovery:
   enableProvisionContainer: true
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,32 @@
+# CI tests
+
+### Running locally
+
+```
+export SKIP_YQ_INSTALL=1
+./tests/e2e-kind.sh
+```
+
+### Debugging the test run
+
+Get a shell inside the ct container
+```
+docker exec -it ct bash
+```
+
+`kubectl` can be used.
+
+examples:
+```
+# list all resources in all namespaces
+kubectl get all -A
+
+# watch for k8s events
+kubectl get events -wA
+
+# find out the namespace used
+kubectl get namespaces -o=name |grep pulsar
+
+# get logs for a crashed container
+kubectl logs -n pulsar-d2t71e2zm3 -p pod/pulsar-function-0
+```

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 readonly CT_VERSION=latest
 readonly KIND_VERSION=v0.11.1
-readonly K8S_VERSION=v1.18.19
+readonly K8S_VERSION=v1.21.2
 
 readonly CLUSTER_NAME=pulsar-helm-test
 

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-
+CI="${CI:-false}"
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -78,10 +78,12 @@ install_charts() {
 }
 
 pull_and_cache_docker_images() {
-    echo 'Installing yq...'
-    curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/v4.9.8/yq_linux_amd64
-    chmod +x ./yq
-    sudo mv yq /usr/local/bin/
+    if [[ $CI == "true" ]]; then
+        echo 'Installing yq...'
+        curl -Lo ./yq https://github.com/mikefarah/yq/releases/download/v4.9.8/yq_linux_amd64
+        chmod +x ./yq
+        sudo mv yq /usr/local/bin/
+    fi
     echo 'Printing yq version'
     yq --version
 

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -92,7 +92,7 @@ pull_and_cache_docker_images() {
     images=$(yq e '.image | .[] |= ([.repository, .tag] | join(":")) | to_entries | .[] | .value' "$SCRIPT_DIR"/../helm-chart-sources/pulsar/values.yaml | sort | uniq)
     for image in $images; do
         docker pull "$image"
-        kind load docker-image --name "$CLUSTER_NAME" --nodes "$nodes" "$image"
+        kind load docker-image -v 1 --name "$CLUSTER_NAME" --nodes "$nodes" "$image"
     done
 }
 

--- a/tests/kind-config.yaml
+++ b/tests/kind-config.yaml
@@ -20,4 +20,3 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
   - role: worker
-  - role: worker


### PR DESCRIPTION
### Motivation

Some processes are failing with OS level out-of-memory error code 143.

### Modifications

- Set -Xms64m parameter to all components to minimize memory usage.
- Limit MaxDirectMemorySize to 256m on bookkeeper, broker and function worker.