### PR TITLE
Chart.lock file should be used to ensure that specific versions are used

### DIFF
--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -68,7 +68,7 @@ find_latest_tag() {
 
 package_chart() {
     local chart="$1"
-    helm dependency update "$chart"
+    helm dependency build "$chart"
     helm package "$chart" --destination .cr-release-packages 
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ Session.vim
 
 # Chart dependencies
 **/charts/*.tgz
-Chart.lock
 
 .history
 

--- a/helm-chart-sources/pulsar/Chart.lock
+++ b/helm-chart-sources/pulsar/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: kube-prometheus-stack
+  repository: https://prometheus-community.github.io/helm-charts
+  version: 12.12.2
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v1.1.1
+- name: envoy
+  repository: https://slamdev.github.io/helm-charts
+  version: 0.0.7
+- name: keycloak
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.0.1
+digest: sha256:9c8e272fe937fd7250d353b1c8b1a1faa0a1bd4cb906b61d1669467915e29c30
+generated: "2021-11-25T14:07:33.960587743+02:00"

--- a/helm-chart-sources/pulsar/requirements.lock
+++ b/helm-chart-sources/pulsar/requirements.lock
@@ -1,9 +1,0 @@
-dependencies:
-- name: kube-prometheus-stack
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 12.12.2
-- name: cert-manager
-  repository: https://charts.jetstack.io
-  version: v1.1.1
-digest: sha256:d41ca5bd0231d23f92d6109208bfe454f2dc1bfea250ffbc8c6655054b3fff82
-generated: "2021-05-31T09:59:36.791371-04:00"


### PR DESCRIPTION
- Chart.lock was removed as part of e983203
- It's recommended to use Chart.lock so that dependent chart versions are specific
- remove requirements.lock which hasn't been used after switching to v2 Chart.yaml