### PR TITLE
Enable TCP keepalive in default PULSAR_EXTRA_OPTS for Zookeeper

### DIFF
--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -500,7 +500,7 @@ zookeeper:
     PULSAR_GC: "-XX:+UseG1GC"
     PULSAR_LOG_LEVEL: "info"
     PULSAR_LOG_ROOT_LEVEL: "info"
-    PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dpulsar.log.root.level=info"
+    PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true -Dpulsar.log.root.level=info"
   ## Zookeeper service
   ## templates/zookeeper-service.yaml
   ##
@@ -571,7 +571,7 @@ zookeepernp:
     PULSAR_GC: "-XX:+UseG1GC"
     PULSAR_LOG_LEVEL: "info"
     PULSAR_LOG_ROOT_LEVEL: "info"
-    PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dpulsar.log.root.level=info"
+    PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true -Dpulsar.log.root.level=info"
   ## Zookeeper service
   ## templates/zookeepernp-service.yaml
   ##

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -500,7 +500,7 @@ zookeeper:
     PULSAR_GC: "-XX:+UseG1GC"
     PULSAR_LOG_LEVEL: "info"
     PULSAR_LOG_ROOT_LEVEL: "info"
-    PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info"
+    PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dpulsar.log.root.level=info"
   ## Zookeeper service
   ## templates/zookeeper-service.yaml
   ##
@@ -571,7 +571,7 @@ zookeepernp:
     PULSAR_GC: "-XX:+UseG1GC"
     PULSAR_LOG_LEVEL: "info"
     PULSAR_LOG_ROOT_LEVEL: "info"
-    PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info"
+    PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dpulsar.log.root.level=info"
   ## Zookeeper service
   ## templates/zookeepernp-service.yaml
   ##


### PR DESCRIPTION
- Add `-Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true` to PULSAR_EXTRA_OPTS
- Enable TCP keepAlive flag on the sockets used by quorum members to perform elections
  - see https://issues.apache.org/jira/browse/ZOOKEEPER-1748 for details
    - "Setting this to true sets the TCP keepAlive flag on the sockets used by
       quorum members to perform elections. This will allow for connections between
       quorum members to remain up when there is network infrastructure that may
       otherwise break them.
       Some NATs and firewalls may terminate or lose state for long running
       or idle connections."
- Enable TCP keepAlive flag on the sockets used for client connections (requires Zookeeper 3.6.1+)
  - see https://issues.apache.org/jira/browse/ZOOKEEPER-3712 for details
    - "Some broken network infrastructure may lose the FIN packet that is sent from closing client.
        These never closed client sockets cause OS resource leak. Enabling this option terminates
        these zombie sockets by idle check. ... Currently this option is only available
        when default NIOServerCnxnFactory is used."