### PR TITLE
Remove quorumListenOnAllIPs=true since it shouldn't be required

### DIFF
--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -36,7 +36,6 @@ data:
   sslQuorum: "true"
   PULSAR_PREFIX_sslQuorum: "true"
   {{- end }}
-  PULSAR_PREFIX_quorumListenOnAllIPs: "true"
 {{ toYaml .Values.zookeeper.configData | indent 2 }}
   # Workaround for double-quoted values in old values files
   PULSAR_MEM: {{ .Values.zookeeper.configData.PULSAR_MEM }}


### PR DESCRIPTION
- it shouldn't be required when `spec.publishNotReadyAddresses: true`
  (or the legacy annotation `service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"`) is used
  for the headless service
- `quorumListenOnAllIPs=true` triggers issue [ZOOKEEPER-2164](https://issues.apache.org/jira/browse/ZOOKEEPER-2164), [ZOOKEEPER-2104](https://issues.apache.org/jira/browse/ZOOKEEPER-2104) ["Quorum members can not rejoin after restart"](https://github.com/apache/zookeeper/commit/800cc26a768fceda9ea42fe8121acf45fe781c57)
  - "So in any 3.5+ ZooKeeper, if wildcard addresses are used in the configs,
then there might be some servers never able to rejoin to the quorum
after they got restarted."
  - fixed in ZK since 3.5.8
  - other alternative is to remove the usage of `quorumListenOnAllIPs=true`
- quorumListenOnAllIPs is considered an unsafe option in Zookeeper
  https://zookeeper.apache.org/doc/current/zookeeperAdmin.html#Unsafe+Options