### PR TITLE
[Pulsar SQL] Remove discovery-server.enabled config

### DIFF
--- a/helm-chart-sources/pulsar/templates/pulsarSql/configmap-worker.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/configmap-worker.yaml
@@ -48,7 +48,6 @@ data:
     http-server.http.port={{ .Values.pulsarSQL.server.config.http.port }}
     query.max-memory={{ .Values.pulsarSQL.server.config.query.maxMemory }}
     query.max-memory-per-node={{ .Values.pulsarSQL.server.config.query.maxMemoryPerNode }}
-    discovery-server.enabled=true
     discovery.uri=http://{{ template "pulsar.fullname" . }}-{{ .Values.pulsarSQL.component }}:{{ .Values.pulsarSQL.server.config.http.port }}
     catalog.config-dir=/pulsar/conf/presto/catalog
 


### PR DESCRIPTION
Fixes https://github.com/datastax/pulsar-helm-chart/issues/86.

As discussed https://groups.google.com/g/presto-users/c/AetYYMvfsiA?pli=1, the `discovery-server.enabled=true` config is no longer allowed in the worker config. I verified this issue with our helm chart by running `helm install test -f examples/dev-values-sql.yaml datastax-pulsar/pulsar` with chart version 2.0.1. I saw the same exception mentioned in the referenced presto mailing list.