### PR TITLE
[Security] Workaround for CVE-2021-44228 Log4J RCE when Log4J >= 2.10.0

### DIFF
--- a/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-deployment.yaml
@@ -203,7 +203,7 @@ spec:
           {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
           /pulsar/tools/certconverter.sh &&
           {{- end }}
-          exec bin/bookkeeper autorecovery
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/bookkeeper autorecovery
         {{- if and .Values.enableTls .Values.tls.zookeeper.enabled}}
         volumeMounts:
         - name: certs

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -211,7 +211,7 @@ spec:
           echo 'dlog.bkcAckQuorumSize={{ .Values.stateStorage.ack }}' >> conf/bookkeeper.conf &&
           {{- end }}
           {{- end }}
-          exec bin/pulsar bookie
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar bookie
         ports:
         - name: client
           containerPort: 3181

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
@@ -246,7 +246,7 @@ spec:
           {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
           /pulsar/tools/certconverter.sh &&
           {{- end }}
-          exec bin/pulsar broker
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar broker
         ports:
         - name: http
           containerPort: 8080

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
@@ -243,7 +243,7 @@ spec:
           {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
           /pulsar/tools/certconverter.sh &&
           {{- end }}
-          exec bin/pulsar broker
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar broker
         ports:
         - name: http
           containerPort: 8080

--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -233,7 +233,7 @@ spec:
           {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
           /pulsar/tools/certconverter.sh &&
           {{- end }}
-          exec bin/pulsar functions-worker
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar functions-worker
         ports:
         - name: functiontls
           containerPort: 6751

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -258,7 +258,7 @@ spec:
           {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
           /pulsar/tools/certconverter.sh &&
           {{- end }}
-          exec bin/pulsar proxy
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar proxy
         ports:
         - name: wss
           containerPort: 8001

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -316,7 +316,7 @@ spec:
           {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
           /pulsar/tools/certconverter.sh &&
           {{- end }}
-          bin/pulsar websocket
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar websocket
         ports:
         - name: http
           containerPort: 8080

--- a/helm-chart-sources/pulsar/templates/pulsarSql/deployment-coordinator.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/deployment-coordinator.yaml
@@ -139,7 +139,7 @@ spec:
               {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
               /pulsar/tools/certconverter.sh &&
               {{- end }}
-              bin/pulsar sql-worker run \
+              OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar sql-worker run \
                 --etc-dir=/pulsar/conf/presto \
                 --data-dir=/pulsar/data;
           ports:

--- a/helm-chart-sources/pulsar/templates/pulsarSql/deployment-worker.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/deployment-worker.yaml
@@ -144,7 +144,7 @@ spec:
               {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
               /pulsar/tools/certconverter.sh &&
               {{- end }}
-              bin/pulsar sql-worker run \
+              OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar sql-worker run \
                 --etc-dir=/pulsar/conf/presto \
                 --data-dir=/pulsar/data;
           ports:

--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-statefulset.yaml
@@ -134,7 +134,7 @@ spec:
           /pulsar/tools/certconverter.sh &&
           {{- end }}
           /pulsar/zookeeper-config/generate-zookeeper-config-mixed.sh conf/zookeeper.conf &&
-          exec bin/pulsar zookeeper
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar zookeeper
         ports:
         - name: client
           containerPort: 2181

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -151,7 +151,7 @@ spec:
           {{- else }}
           bin/generate-zookeeper-config.sh conf/zookeeper.conf &&
           {{- end }}
-          exec bin/pulsar zookeeper
+          OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar zookeeper
         ports:
         - name: client
           containerPort: 2181


### PR DESCRIPTION
### Motivation

CVE-2021-44228 , a severe RCE for Log4J.

The workaround is to set `-Dlog4j2.formatMsgNoLookups=true` system property. This workaround applies for Log4J >= 2.10.0 . This covers all vulnerable Pulsar versions since Log4J2 version was 2.10.0 when the dependency was introduced to Pulsar in https://github.com/apache/pulsar/pull/680 .

### Modifications

Add `OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true"` prefix to calls to `exec bin/pulsar` and `exec bin/bookkeeper` . This results in `-Dlog4j2.formatMsgNoLookups=true` system property getting set.