### PR TITLE
Use stable v1 API release of priorityClass

### DIFF
--- a/helm-chart-sources/pulsar/templates/utils/priorityclass.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/priorityclass.yaml
@@ -16,7 +16,7 @@
 #
 
 {{- if .Values.priorityClass.enabled }}
-apiVersion: scheduling.k8s.io/v1beta1
+apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: pulsar-priority


### PR DESCRIPTION
As of k8s 1.22 scheduling.k8s.io/v1beta1 is unavailablke (deprecated since 1.14)
This change should allow for a deployment of the pulsar chart on k8s 1.22

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#priorityclass-v122