### PR TITLE
Add LOG4J_FORMAT_MSG_NO_LOOKUPS=true env to all containers

### DIFF
--- a/helm-chart-sources/pulsar/Chart.lock
+++ b/helm-chart-sources/pulsar/Chart.lock
@@ -5,11 +5,8 @@ dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.1.1
-- name: envoy
-  repository: https://slamdev.github.io/helm-charts
-  version: 0.0.7
 - name: keycloak
   repository: https://charts.bitnami.com/bitnami
   version: 5.0.1
-digest: sha256:9c8e272fe937fd7250d353b1c8b1a1faa0a1bd4cb906b61d1669467915e29c30
-generated: "2021-11-25T14:07:33.960587743+02:00"
+digest: sha256:47cdf1a3ab65803006e6e3037043de119a5f27ef1d763aeda76881394415341a
+generated: "2021-12-12T17:56:37.452676318+02:00"

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-deployment.yaml
@@ -119,6 +119,8 @@ spec:
             readOnly: true
           {{- end }}
         env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           {{- if .Values.enableTokenAuth }}
           - name: token_path
             value: "/pulsar/token-superuser/superuser.jwt"

--- a/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-deployment.yaml
@@ -175,6 +175,8 @@ spec:
         ports:
         volumeMounts:
         env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: ClusterName
             value: "{{ template "pulsar.fullname" . }}"
           - name: SuperRoles
@@ -212,6 +214,9 @@ spec:
         - name: certconverter
           mountPath: /pulsar/tools
         {{- end }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.autoRecovery.component }}"

--- a/helm-chart-sources/pulsar/templates/bastion/bastion-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion/bastion-deployment.yaml
@@ -110,6 +110,8 @@ spec:
             mountPath: /pulsar/certs
           {{- end }}
         env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: PORT
             value: "8964"
           - name: ClusterName
@@ -171,6 +173,8 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bastion.component }}"
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         # If proxy is deployed, use that for web service URL to
         # properly forward command to broker or function worker
         {{- if .Values.extra.proxy }}

--- a/helm-chart-sources/pulsar/templates/beam/beamwh-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/beam/beamwh-deployment.yaml
@@ -178,6 +178,8 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarBeam.component }}"
         env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: ProcessMode
             value: "broker"
           - name: PORT

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -166,6 +166,9 @@ spec:
           bin/apply-config-from-env.py conf/bookkeeper.conf &&
           bin/apply-config-from-env.py conf/bkenv.sh &&
           bin/bookkeeper shell metaformat --nonInteractive || true;
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
@@ -215,6 +218,9 @@ spec:
         ports:
         - name: client
           containerPort: 3181
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
@@ -287,6 +287,8 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         - name: advertisedAddress
           valueFrom:
             fieldRef:

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
@@ -285,6 +285,8 @@ spec:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}"
         {{- if .Values.brokerSts.ledger }}
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         - name: advertisedAddress
           valueFrom:
             fieldRef:

--- a/helm-chart-sources/pulsar/templates/dns/dns-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/dns/dns-deployment.yaml
@@ -80,6 +80,8 @@ spec:
         {{- end }}
         {{- if eq .Values.dns.provider "digitalocean" }}
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         - name: DO_TOKEN
           value: "{{ .Values.dns.digitalOceanApiKey}}"
         {{- end  }}

--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -243,6 +243,8 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-extra"
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         - name: workerHostname
           valueFrom:
             fieldRef:
@@ -296,6 +298,8 @@ spec:
         - name: burnelllog
           containerPort: 4040
         env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: LogServerPort
             value: ":4040"
           - name: FunctionLogPathPrefix

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -292,6 +292,9 @@ spec:
           - name: lib-data
             mountPath: {{ .Values.proxy.initContainer.emptyDirPath }}
           {{- end }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
@@ -343,6 +346,9 @@ spec:
             name: token-websocket
             readOnly: true
           {{- end }}
+        env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-ws"
@@ -363,6 +369,8 @@ spec:
             readOnly: true
             mountPath: /pulsar/certs
         env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: PORT
             value: "8500"
           - name: CA_PATH
@@ -400,6 +408,8 @@ spec:
             name: token-public-key
             readOnly: true
         env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: ROLES
             value: {{ .Values.tokenServer.allowedRoles }}
 {{- end }}
@@ -430,6 +440,8 @@ spec:
           {{- end }}
         args: ["-mode", "http"]
         env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: ProcessMode
             value: "http"
           - name: PORT
@@ -506,6 +518,8 @@ spec:
             readOnly: true
           {{- end }}
         env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: PORT
             value: "8964"
           - name: ClusterName

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
@@ -96,6 +96,8 @@ spec:
           - name: config-volume
             mountPath: /config
           env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: DeployEnv
             value: production
           - name: ClusterName

--- a/helm-chart-sources/pulsar/templates/pulsarSql/deployment-coordinator.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/deployment-coordinator.yaml
@@ -81,6 +81,8 @@ spec:
           {{- if .Values.storageOffload.driver }}
           {{- if eq .Values.storageOffload.driver "aws-s3" }}
           env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: AWS_ACCESS_KEY_ID
             value: {{ .Values.storageOffload.accessKey }}
           - name: AWS_SECRET_ACCESS_KEY

--- a/helm-chart-sources/pulsar/templates/pulsarSql/deployment-worker.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/deployment-worker.yaml
@@ -83,6 +83,8 @@ spec:
           {{- if .Values.storageOffload.driver }}
           {{- if eq .Values.storageOffload.driver "aws-s3" }}
           env:
+          - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+            value: "true"
           - name: AWS_ACCESS_KEY_ID
             value: {{ .Values.storageOffload.accessKey }}
           - name: AWS_SECRET_ACCESS_KEY

--- a/helm-chart-sources/pulsar/templates/tardigrade/deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/tardigrade/deployment.yaml
@@ -59,6 +59,8 @@ spec:
         - name: config-props
           mountPath: /configmap
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         - name: CONF_PATH
           value: "/config"
         ports:

--- a/helm-chart-sources/pulsar/templates/tests/beam-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/beam-test.yaml
@@ -82,6 +82,8 @@ spec:
           bin/apply-config-from-env.py conf/client.conf &&
           /pulsar/tests/test.sh
     env:
+    - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+      value: "true"
     - name: webServiceUrl
       value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080/
     - name: brokerServiceUrl

--- a/helm-chart-sources/pulsar/templates/tests/offload-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/offload-test.yaml
@@ -90,6 +90,8 @@ spec:
           bin/apply-config-from-env.py conf/client.conf &&
           /pulsar/tests/test.sh
     env:
+    - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+      value: "true"
     - name: webServiceUrl
       value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080/
     - name: brokerServiceUrl

--- a/helm-chart-sources/pulsar/templates/tests/schema-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/schema-test.yaml
@@ -162,6 +162,8 @@ spec:
           bin/apply-config-from-env.py conf/client.conf &&
           /pulsar/tests/test.sh
     env:
+    - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+      value: "true"
     - name: webServiceUrl
       value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080/
     - name: brokerServiceUrl

--- a/helm-chart-sources/pulsar/templates/tests/tls-beam-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-beam-test.yaml
@@ -82,6 +82,8 @@ spec:
           bin/apply-config-from-env.py conf/client.conf &&
           /pulsar/tests/test.sh
     env:
+    - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+      value: "true"
     - name: webServiceUrl
       value: https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8443/
     - name: brokerServiceUrl

--- a/helm-chart-sources/pulsar/templates/tests/tls-broker.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-broker.yaml
@@ -48,6 +48,8 @@ spec:
   - name: "{{ template "pulsar.fullname" . }}-test-client-broker-tls"
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     env:
+    - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+      value: "true"
       {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled}}
       - name: tlsTrustCertsFilePath
         value: /pulsar/certs/ca.crt

--- a/helm-chart-sources/pulsar/templates/tests/tls-proxy.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-proxy.yaml
@@ -49,6 +49,8 @@ spec:
   - name: "{{ template "pulsar.fullname" . }}-test-client-proxy-tls"
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     env:
+    - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+      value: "true"
       {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled}}
       - name: tlsTrustCertsFilePath
         value: /pulsar/certs/ca.crt

--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-statefulset.yaml
@@ -143,6 +143,8 @@ spec:
         - name: leader-election
           containerPort: 3888
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         - name: ZOOKEEPER_SERVERS
           value:
             {{ include "pulsar.zkConnectString" . }}

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -160,6 +160,8 @@ spec:
         - name: leader-election
           containerPort: 3888
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         - name: ZOOKEEPER_SERVERS
           value:
             {{- if .Values.extra.zookeepernp }}

--- a/helm-chart-sources/pulsar/templates/zoonavigator/zoonavigator-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/zoonavigator/zoonavigator-deployment.yaml
@@ -78,6 +78,8 @@ spec:
         - name: http
           containerPort: 8001
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         - name: API_HOST
           value: "localhost"
         - name: API_PORT
@@ -104,6 +106,8 @@ spec:
         - name: api
           containerPort: 9001
         env:
+        - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+          value: "true"
         - name: API_HTTP_PORT
           value: "9001"
 {{- end }}


### PR DESCRIPTION
### Motivation

- required for disabling the CVE-2021-44228 vulnerable feature in Log4J 2.x in Pulsar Functions when using the process runtime.
- add environment variable to all containers as a extra safety measure

### Additional context

- please notice that for mitigating the k8s runtime for Pulsar Functions, it's necessary
  to patch the used docker image, more information in
  https://github.com/lhotari/pulsar-docker-images-patch-CVE-2021-44228
  pulsarDockerImageName setting should point to the patched image

- https://twitter.com/brunoborges/status/1469462412679991300 contains information about the LOG4J_FORMAT_MSG_NO_LOOKUPS=true workaround.

### Modifications

Add LOG4J_FORMAT_MSG_NO_LOOKUPS=true environment variable workaround to all possible locations as an additional mitigation which also covers forked Java processes.