### PR TITLE
[Pulsar SQL] Fix liveness and readiness probes

### DIFF
--- a/examples/dev-values-sql.yaml
+++ b/examples/dev-values-sql.yaml
@@ -95,6 +95,8 @@ proxy:
       enabled: true
 
 pulsarSQL:
+  server:
+    workers: 1
   resources:
     requests:
       memory: 512Mi

--- a/helm-chart-sources/pulsar/templates/pulsarSql/deployment-worker.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/deployment-worker.yaml
@@ -147,28 +147,20 @@ spec:
               OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar sql-worker run \
                 --etc-dir=/pulsar/conf/presto \
                 --data-dir=/pulsar/data;
-          ports:
-            - name: http-coord
-              containerPort: {{ .Values.pulsarSQL.server.config.http.port }}
-              protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /v1/service/presto
-              port: http-coord
+            exec:
+              command:
+                - /bin/bash
+                - /pulsar/conf/presto/health_check.sh
             initialDelaySeconds: 10
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 3
-            failureThreshold: 4
+            periodSeconds: 25
           readinessProbe:
-            httpGet:
-              path: /v1/service/presto
-              port: http-coord
-            initialDelaySeconds: 10
+            exec:
+              command:
+                - /bin/bash
+                - /pulsar/conf/presto/health_check.sh
+            initialDelaySeconds: 5
             periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 3
-            failureThreshold: 4
           resources:
 {{ toYaml .Values.pulsarSQL.resources | indent 12 }}
     {{- with .Values.pulsarSQL.nodeSelector }}


### PR DESCRIPTION
Fixes #87 

The basic fix is to revert the changes made to the presto worker deployment's liveness and readiness probes made in #5. I verified this change using minikube and the `example/dev-values-sql.yaml` file.