### PR TITLE
Use Kubernetes to ensure correct fs permissions on persistent volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ It includes support for:
 [Helm](https://helm.sh) must be installed and initialized to use the chart. Only Helm 3 is supported.
 Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 
+## Upgrade considerations
+
+### Luna Streaming 2.7.2
+
+For helm chart versions prior to 2.10.0, we recommended using the `fixRootlessPermissions` field in your `values.yaml`
+to make non-root docker images work correctly. In 2.10.0, we updated the chart to use the `securityContext` to ensure
+correct file system permissions. The `fixRootlessPermissions` was therefore removed in 2.10.0, since it was not
+necessary and an unused value field has no effect on deployment.
+
 ## Minikube quick start
 
 Make sure you have minikube [installed](https://minikube.sigs.k8s.io/docs/start/) and running (`minikube start`).

--- a/README.md
+++ b/README.md
@@ -25,28 +25,6 @@ It includes support for:
 [Helm](https://helm.sh) must be installed and initialized to use the chart. Only Helm 3 is supported.
 Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 
-## Upgrade considerations
-
-### Luna Streaming 2.7.2
-
-Starting in Luna Streaming 2.7.2, the Pulsar containers run as a non-root user for enhanced security. When upgrading files created in prior version will have root permissions and will not be readable by containers running the new version.
-
-To fix this, you can manually log into the ZooKeeper, BookKeeper, and Function Worker pods and make sure that all files in the `/pulsar/data/` and `pulsar/logs` directories are owned by UID 10000 (user pulsar). 
-The group ID of the files should also be set to GID 10001 (group pulsar). Here is an example command:
-
-```
-chown -R 10000:10001 /pulsar/data
-```
-
-Alternatively, you can enable automatic fixing of the permissions using an init container, with the following setting:
-
-```
-fixRootlessPermissions:
-  enabled: true
-```
-
-Note that this setting only needs to be enabled during the migration to the non-root user version. Once the cluster has been upgraded this setting can be disabled for future upgrades.
-
 ## Minikube quick start
 
 Make sure you have minikube [installed](https://minikube.sigs.k8s.io/docs/start/) and running (`minikube start`).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 # Helm Chart for an Apache Pulsar Cluster
 
 This Helm chart configures an Apache Pulsar cluster. It is designed for production use, but can also be used in local development environments with the proper settings.
+It requires Kubernetes version 1.18+.
 
 It includes support for:
 * [TLS](#tls)

--- a/examples/dev-values-auth.yaml
+++ b/examples/dev-values-auth.yaml
@@ -18,8 +18,6 @@
 enableAntiAffinity: false
 enableTls: false
 enableTokenAuth: true
-fixRootlessPermissions:
-  enabled: true
 restartOnConfigMapChange:
   enabled: true
 extra:

--- a/examples/dev-values-keycloak-auth-tls.yaml
+++ b/examples/dev-values-keycloak-auth-tls.yaml
@@ -46,8 +46,6 @@ image:
     pullPolicy: IfNotPresent
     tag: 2.8.0_1.1.3
 
-fixRootlessPermissions:
-  enabled: true
 enableAntiAffinity: false
 enableTls: true
 #tls:

--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -52,8 +52,6 @@ enableTls: false
 enableTokenAuth: true
 restartOnConfigMapChange:
   enabled: true
-fixRootlessPermissions:
-  enabled: true
 extra:
   function: true
   burnell: true

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -118,32 +118,6 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bookkeeper.gracePeriod }}
       initContainers:
-      {{- if .Values.fixRootlessPermissions.enabled }}
-      # This init container will make sure permissions are set correctly for the rootless container
-      - name: fix-rootless-permissions
-        image: {{ .Values.fixRootlessPermissions.containerImage }}
-        imagePullPolicy: IfNotPresent
-        command: ["sh", "-c"]
-        volumeMounts:
-        {{- if and .Values.bookkeeper.volumes.oneDisk}}
-        - name: "{{ .Values.bookkeeper.pvcPrefix}}{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.oneDisk.name }}"
-          mountPath: /pulsar/data
-        {{- else }}
-        - name: "{{ .Values.bookkeeper.pvcPrefix}}{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
-          mountPath: /pulsar/data/bookkeeper/journal
-        {{- if and .Values.bookkeeper.volumes.ranges .Values.function.enableStateStorage}}
-        {{- if not (or .Values.extra.stateStorage .Values.function.stateStorageUrlOverride) }}
-        - name: "{{ .Values.bookkeeper.pvcPrefix}}{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ranges.name }}"
-          mountPath: /pulsar/data/bookkeeper/ranges
-        {{- end }}
-        {{- end }}
-        - name: "{{ .Values.bookkeeper.pvcPrefix}}{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
-          mountPath: /pulsar/data/bookkeeper/ledgers
-        {{- end }}
-        args:
-          - >
-            chown -R 10000:10001 /pulsar/data/
-      {{- end }}
       # This init container will wait for zookeeper to be ready before
       # deploying the bookies
       - name: wait-zookeeper-ready

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -143,6 +143,9 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
         image: "{{ .Values.image.bookkeeper.repository }}:{{ .Values.image.bookkeeper.tag }}"

--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -175,6 +175,9 @@ spec:
           - name: extra-data
             mountPath: {{ .Values.function.initContainer.emptyDirPath }}
       {{- end }}
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"
         image: "{{ .Values.image.function.repository }}:{{ .Values.image.function.tag }}"

--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -158,21 +158,8 @@ spec:
         - name: extra-data
           emptyDir: {}
       {{- end }}
-      initContainers:
-      {{- if .Values.fixRootlessPermissions.enabled }}
-      # This init container will make sure permissions are set correctly for the rootless container
-      - name: fix-rootless-permissions
-        image: {{ .Values.fixRootlessPermissions.containerImage }}
-        imagePullPolicy: IfNotPresent
-        command: [ "sh", "-c" ]
-        volumeMounts:
-        - name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-{{ .Values.function.volumes.data.name }}"
-          mountPath: /pulsar/logs
-        args:
-          - >
-            chown -R 10000:10001 /pulsar/logs
-      {{- end }}
       {{- if .Values.function.initContainer }}
+      initContainers:
       - name: add-libs
         image: "{{ .Values.function.initContainer.repository }}:{{ .Values.function.initContainer.tag }}"
         imagePullPolicy: "{{ .Values.function.initContainer.pullPolicy }}"

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -117,6 +117,9 @@ spec:
         {{- end }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
         image: "{{ .Values.image.zookeeper.repository }}:{{ .Values.image.zookeeper.tag }}"

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -117,20 +117,6 @@ spec:
         {{- end }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}
-      {{- if .Values.fixRootlessPermissions.enabled }}
-      initContainers:
-      # This init container will make sure permisisons are set correctly for the rootless container
-      - name: fix-rootless-permissions
-        image: {{ .Values.fixRootlessPermissions.containerImage }}
-        imagePullPolicy: IfNotPresent
-        command: ["sh", "-c"]
-        volumeMounts:
-          - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}"
-            mountPath: /pulsar/data
-        args:
-          - >
-            chown -R 10000:10001 /pulsar/data
-      {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
         image: "{{ .Values.image.zookeeper.repository }}:{{ .Values.image.zookeeper.tag }}"

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -212,16 +212,6 @@ enableTests: false
 # Also enabled extended tests
 enableExtendedTests: false
 
-# When upgrading to Luna Streaming version 2.7.2 (or higher) from any prior version, the 2.7.2 containers
-# do not run as root for enhanced security. Because of this, the containers may not have the correct
-# permissions to read files. This is remediated by fixing the file system permissions in an init container.
-#
-# In most cases this is not required for new installations. However, depending on how volumes are mounted
-# it may be necessary to enable this feature even for new installations.
-fixRootlessPermissions:
-  enabled: false
-  containerImage: openjdk:11-jdk-slim
-
 # By default, Kubernetes will not restart pods when only their
 # configmap is changed. This setting will restart pods when their
 # configmap is changed using an annotation that calculates the


### PR DESCRIPTION
## Motivation
Remove all reliance on running containers as the root user. Rely on kubernetes to set the file system permissions on all mounted volumes (that includes secrets, config maps, and persistent volumes).

## Changes

* Revert the initial patch to add `fixRootlessPermissions`
* Add `securityContext` to bookkeeper, zookeeper, and function worker pod specs.
    * Use the root fsGroup to ensure compatibility with OpenShift
    * Use `fsGroupChangePolicy: "OnRootMismatch"` to limit impact. This feature was beta in 1.20, but based on my testing, it was available in the kube api as early as 1.18.0. I tested this by running minikube 1.18.0, and this helm chart change cleanly applied. It failed when running against 1.17.0 with the error `Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec.template.spec.securityContext): unknown field "fsGroupChangePolicy" in io.k8s.api.core.v1.PodSecurityContext`.

@lhotari and @cdbartholomew - since EKS no longer supports 1.17, I think we're safe to deploy this as a hard coded config that everyone receives. I don't know of any requirements that indicate a container should not run as a member of the root group. If we get this requirement later, we can always make this configuration into a value parameter.
 