### PR TITLE
Improve zk init job to handle slow to start zk

### DIFF
--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
@@ -55,9 +55,11 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            until nslookup {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ add (.Values.zookeeper.replicaCount | int) -1 }}.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }}; do
+            until [ "$(echo ruok | nc {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ add (.Values.zookeeper.replicaCount | int) -1 }}.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }} 2181)" = "imok" ]; do
+              echo Zookeeper not yet ready. Will try again after 3 seconds.
               sleep 3;
             done;
+            echo Zookeeper is ready.
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeperMetadata.component }}"
         image: "{{ .Values.image.zookeeper.repository }}:{{ .Values.image.zookeeper.tag }}"
@@ -78,6 +80,6 @@ spec:
               --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}:6651/ \
               {{- end }}
               --web-service-url http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}:8080/ \
-              --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}:6650/ || true;
+              --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}:6650/;
       restartPolicy: Never
 {{- end }}


### PR DESCRIPTION
There is currently a race in the zookeeper initialization logic. When zookeeper's DNS entry gets created, the `pulsar-zookeeper-metadata` job can start the initialization script too early. When that happens, we end up failing to initialize zookeeper, and then because we end the command with `|| true`, we exit with code 0, which signals to k8s that the job completed successfully.

I make two changes. First, I follow the same paradigm used in the zookeeper health check script to check on zookeeper's readiness. Second, I remove the `|| true`. If the script fails, we should rely on kubernetes to retry the job. The downside to removing `|| true` is that users may see a pod in the error state, if the first pod failed. In order to reduce the probability of failure, I improved the `initContainer` script.

I verified this change using minikube, which is also where I observed the failure case.

@lhotari and @cdbartholomew - PTAL.