### PR TITLE
Bump up zoonavigator version 

### DIFF
--- a/helm-chart-sources/pulsar/templates/zoonavigator/zoonavigator-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/zoonavigator/zoonavigator-deployment.yaml
@@ -82,7 +82,7 @@ spec:
           value: "localhost"
         - name: API_PORT
           value: "9001"
-        - name: WEB_HTTP_PORT
+        - name: HTTP_PORT
           value: "8001"
         {{- if .Values.zoonavigator.autoConnect }}
         # Will set Zoonavigator to autoconnect to Zookeepers
@@ -104,6 +104,6 @@ spec:
         - name: api
           containerPort: 9001
         env:
-        - name: API_HTTP_PORT
+        - name: HTTP_PORT
           value: "9001"
 {{- end }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1501,9 +1501,9 @@ zoonavigator:
       cpu: 0.1
   image:
     repository:
-      web: elkozmon/zoonavigator-web
-      api: elkozmon/zoonavigator-api
-    tag: 0.6.0
+      web: elkozmon/zoonavigator
+      api: elkozmon/zoonavigator
+    tag: latest
     pullPolicy: IfNotPresent
 
   ## Zoonavigator service


### PR DESCRIPTION
The current zoonavigator docker image version in the helm chart is 0.6 which is deprecated.
Bump up the version to the latest version.