### PR TITLE
Use policy/v1 PodDisruptionBudget, if possible

### DIFF
--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-pdb.yaml
@@ -16,7 +16,11 @@
 #
 
 {{- if .Values.bookkeeper.pdb.usePolicy }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-pdb.yaml
@@ -16,7 +16,7 @@
 #
 
 {{- if .Values.bookkeeper.pdb.usePolicy }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-pdb.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.extra.broker }}
 {{- if .Values.broker.pdb.usePolicy }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-pdb.yaml
@@ -17,7 +17,11 @@
 
 {{- if .Values.extra.broker }}
 {{- if .Values.broker.pdb.usePolicy }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-pdb.yaml
@@ -17,7 +17,11 @@
 
 {{- if .Values.extra.brokerSts }}
 {{- if .Values.brokerSts.pdb.usePolicy }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}"

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-pdb.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.extra.brokerSts }}
 {{- if .Values.brokerSts.pdb.usePolicy }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}"

--- a/helm-chart-sources/pulsar/templates/function/function-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-pdb.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.extra.function }}
 {{- if .Values.function.pdb.usePolicy }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"

--- a/helm-chart-sources/pulsar/templates/function/function-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-pdb.yaml
@@ -17,7 +17,11 @@
 
 {{- if .Values.extra.function }}
 {{- if .Values.function.pdb.usePolicy }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-pdb.yaml
@@ -17,7 +17,11 @@
 
 {{- if .Values.extra.proxy }}
 {{- if .Values.proxy.pdb.usePolicy }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-pdb.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.extra.proxy }}
 {{- if .Values.proxy.pdb.usePolicy }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"

--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-pdb.yaml
@@ -17,7 +17,11 @@
 
 {{- if .Values.extra.zookeepernp }}
 {{- if .Values.zookeepernp.pdb.usePolicy }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}"

--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-pdb.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.extra.zookeepernp }}
 {{- if .Values.zookeepernp.pdb.usePolicy }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}"

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-pdb.yaml
@@ -16,7 +16,7 @@
 #
 
 {{- if .Values.zookeeper.pdb.usePolicy }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-pdb.yaml
@@ -16,7 +16,11 @@
 #
 
 {{- if .Values.zookeeper.pdb.usePolicy }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
 apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"


### PR DESCRIPTION
In Kubernetes 1.21, the `PodDisruptionBudget` moves from v1beta1 to v1. Based on the documented changes, https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125, this update does not affect any behavior for our helm chart.

In order to prevent breaking changes for our users, we can only merge this PR once our minimum kubernetes version is 1.21.

Note that the v1beta1 api is removed in kubernetes 1.25.