### PR TITLE
Remove duplicate PULSAR_MEM and PULSAR_GC keys from ConfigMaps

### DIFF
--- a/examples/dev-values-auth.yaml
+++ b/examples/dev-values-auth.yaml
@@ -34,7 +34,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
 
 bookkeeper:
   replicaCount: 1
@@ -43,7 +43,7 @@ bookkeeper:
       memory: 512Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 broker:
   component: broker
@@ -57,7 +57,7 @@ broker:
       memory: 600Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 autoRecovery:
   enableProvisionContainer: true
@@ -74,7 +74,7 @@ function:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 proxy:
   replicaCount: 1
@@ -87,7 +87,7 @@ proxy:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m"
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:

--- a/examples/dev-values-keycloak-auth-tls.yaml
+++ b/examples/dev-values-keycloak-auth-tls.yaml
@@ -108,7 +108,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
 
 bookkeeper:
   replicaCount: 1
@@ -117,7 +117,7 @@ bookkeeper:
       memory: 512Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 broker:
   component: broker
@@ -132,7 +132,7 @@ broker:
       cpu: 0.3
   authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID"
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
     PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info -Djavax.net.ssl.keyStore=/pulsar/certs/keystore.jks -Djavax.net.ssl.trustStore=/pulsar/certs/truststore.jks -Djavax.net.ssl.trustStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR -Djavax.net.ssl.keyStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR"
 
 autoRecovery:
@@ -151,7 +151,7 @@ function:
       cpu: 0.3
   authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
   configData:
-    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
     PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info -Djavax.net.ssl.keyStore=/pulsar/certs/keystore.jks -Djavax.net.ssl.trustStore=/pulsar/certs/truststore.jks -Djavax.net.ssl.trustStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR -Djavax.net.ssl.keyStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR"
 
 proxy:
@@ -167,7 +167,7 @@ proxy:
   authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID"
   wsAuthenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m"
     PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info -Djavax.net.ssl.keyStore=/pulsar/certs/keystore.jks -Djavax.net.ssl.trustStore=/pulsar/certs/truststore.jks -Djavax.net.ssl.trustStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR -Djavax.net.ssl.keyStorePassword=kU4Fv3Qb8zfe-BK7drdhsX.pmau9FR"
   autoPortAssign:
     enablePlainTextWithTLS: true

--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -76,7 +76,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
 
 bookkeeper:
   replicaCount: 1
@@ -85,7 +85,7 @@ bookkeeper:
       memory: 512Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 broker:
   component: broker
@@ -100,7 +100,7 @@ broker:
       cpu: 0.3
   authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID"
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 autoRecovery:
   enableProvisionContainer: true
@@ -118,7 +118,7 @@ function:
       cpu: 0.3
   authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
   configData:
-    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 proxy:
   replicaCount: 1
@@ -133,7 +133,7 @@ proxy:
   authenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID"
   wsAuthenticationProviders: "com.datastax.oss.pulsar.auth.AuthenticationProviderOpenID,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m"
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:

--- a/examples/dev-values-kop-proxy-tls.yaml
+++ b/examples/dev-values-kop-proxy-tls.yaml
@@ -42,7 +42,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
 
 bookkeeper:
   replicaCount: 1
@@ -51,7 +51,7 @@ bookkeeper:
       memory: 512Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 broker:
   component: broker
@@ -82,7 +82,7 @@ broker:
       memory: 200Mi
       cpu: 0.1
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
   kafkaOnPulsarEnabled: true
   kafkaOnPulsar:    
     saslAllowedMechanisms: PLAIN
@@ -105,7 +105,7 @@ function:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 proxy:
   replicaCount: 1
@@ -118,7 +118,7 @@ proxy:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m"
     PULSAR_PREFIX_kafkaListeners: "SASL_PLAINTEXT://0.0.0.0:9092,SASL_SSL://0.0.0.0:9093"
 # here you have to customize the advertised name if you want to access
 # KOP from outside the kube    

--- a/examples/dev-values-kop-proxy.yaml
+++ b/examples/dev-values-kop-proxy.yaml
@@ -73,7 +73,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
 
 bookkeeper:
   replicaCount: 1
@@ -82,7 +82,7 @@ bookkeeper:
       memory: 512Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 broker:
   component: broker
@@ -115,7 +115,7 @@ broker:
       memory: 200Mi
       cpu: 0.1
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
   kafkaOnPulsarEnabled: true
   kafkaOnPulsar:    
     saslAllowedMechanisms: PLAIN
@@ -138,7 +138,7 @@ function:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 proxy:
   replicaCount: 1
@@ -151,7 +151,7 @@ proxy:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m"
     PULSAR_PREFIX_kafkaListeners: "SASL_PLAINTEXT://0.0.0.0:9092"
     PULSAR_PREFIX_kafkaAdvertisedListeners: "SASL_PLAINTEXT://pulsar-proxy:9092"
     PULSAR_PREFIX_saslAllowedMechanisms: PLAIN

--- a/examples/dev-values-rabbitmq-tls.yaml
+++ b/examples/dev-values-rabbitmq-tls.yaml
@@ -42,7 +42,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
 
 bookkeeper:
   replicaCount: 1
@@ -51,7 +51,7 @@ bookkeeper:
       memory: 512Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 broker:
   component: broker
@@ -65,7 +65,7 @@ broker:
       memory: 600Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 autoRecovery:
   enableProvisionContainer: true
@@ -82,7 +82,7 @@ function:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 proxy:
   replicaCount: 1
@@ -95,7 +95,7 @@ proxy:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m"
     PULSAR_PREFIX_amqpListeners: "amqp://0.0.0.0:5672,amqps://0.0.0.0:5671"
     # The rabbitmq extension will use the superuser user for its operations on the broker
     PULSAR_PREFIX_amqpBrokerClientAuthenticationParameters: "file:///pulsar/token-superuser/superuser.jwt"

--- a/examples/dev-values-sql.yaml
+++ b/examples/dev-values-sql.yaml
@@ -35,7 +35,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
 
 bookkeeper:
   replicaCount: 1
@@ -44,7 +44,7 @@ bookkeeper:
       memory: 512Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 broker:
   component: broker
@@ -58,7 +58,7 @@ broker:
       memory: 600Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 autoRecovery:
   resources:
@@ -74,7 +74,7 @@ function:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 proxy:
   replicaCount: 1
@@ -87,7 +87,7 @@ proxy:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m"
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:

--- a/examples/dev-values-tls.yaml
+++ b/examples/dev-values-tls.yaml
@@ -41,7 +41,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
 
 bookkeeper:
   replicaCount: 1
@@ -50,7 +50,7 @@ bookkeeper:
       memory: 512Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 broker:
   component: broker
@@ -64,7 +64,7 @@ broker:
       memory: 600Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 autoRecovery:
   resources:
@@ -80,7 +80,7 @@ function:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 proxy:
   replicaCount: 1
@@ -93,7 +93,7 @@ proxy:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m"
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:

--- a/examples/dev-values.yaml
+++ b/examples/dev-values.yaml
@@ -34,7 +34,7 @@ zookeeper:
       memory: 300Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
 
 bookkeeper:
   replicaCount: 1
@@ -43,7 +43,7 @@ bookkeeper:
       memory: 512Mi
       cpu: 0.3
   configData:
-    BOOKIE_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 broker:
   component: broker
@@ -57,7 +57,7 @@ broker:
       memory: 600Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 autoRecovery:
   resources:
@@ -73,7 +73,7 @@ function:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
 proxy:
   replicaCount: 1
@@ -86,7 +86,7 @@ proxy:
       memory: 512Mi
       cpu: 0.3
   configData:
-    PULSAR_MEM: "\"-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m\""
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m"
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:

--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -48,7 +48,7 @@ zookeeper:
       memory: 300Mi
       cpu: 100m
   configData:
-    PULSAR_MEM: "\"-Xms64m -Xmx128m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError\""
+    PULSAR_MEM: "-Xms64m -Xmx128m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
 
 bookkeeper:
   replicaCount: 1
@@ -96,7 +96,7 @@ proxy:
       memory: 400Mi
       cpu: 100m
   configData:
-    PULSAR_MEM: "\"-Xms64m -Xmx64m -XX:MaxDirectMemorySize=64m\""
+    PULSAR_MEM: "-Xms64m -Xmx64m -XX:MaxDirectMemorySize=64m"
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:

--- a/helm-chart-sources/pulsar/templates/bastion/bastion-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion/bastion-configmap.yaml
@@ -39,7 +39,4 @@ data:
   tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
 {{ toYaml .Values.bastion.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.bastion.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.bastion.configData.PULSAR_GC }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -219,7 +219,4 @@ data:
 {{- end }}
 {{- end }}
 {{ toYaml .Values.broker.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.broker.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.broker.configData.PULSAR_GC }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -220,6 +220,4 @@ data:
 {{- end }}
 {{ toYaml .Values.brokerSts.configData | indent 2 }}
   # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.brokerSts.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.brokerSts.configData.PULSAR_GC }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
@@ -39,7 +39,4 @@ data:
   brokerClientAuthenticationParameters: "file:///pulsar/token-superuser/superuser.jwt"
   {{- end }}
 {{ toYaml .Values.function.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.function.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.function.configData.PULSAR_GC }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -118,9 +118,6 @@ data:
   brokerClientAuthenticationParameters: "file:///pulsar/token-proxy/proxy.jwt"
 {{- end }}
 {{ toYaml .Values.proxy.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.proxy.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.proxy.configData.PULSAR_GC }}
 {{- end }}
 {{- if .Values.proxy.extensions.enabled }}
   PULSAR_PREFIX_proxyExtensionsDirectory: "{{ .Values.proxy.extensions.directory }}"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -76,7 +76,4 @@ data:
   {{- end }}
 {{- end }}
 {{ toYaml .Values.proxy.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.proxy.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.proxy.configData.PULSAR_GC }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-configmap.yaml
@@ -38,7 +38,4 @@ data:
   PULSAR_PREFIX_sslQuorum: "true"
   {{- end }}
 {{ toYaml .Values.zookeepernp.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.zookeepernp.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.zookeepernp.configData.PULSAR_GC }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -37,6 +37,3 @@ data:
   PULSAR_PREFIX_sslQuorum: "true"
   {{- end }}
 {{ toYaml .Values.zookeeper.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.zookeeper.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.zookeeper.configData.PULSAR_GC }}


### PR DESCRIPTION
This is a breaking change for any users that still have values files that use an escaped double quote `\"` for either of these values.

Fixes: https://github.com/datastax/pulsar-helm-chart/issues/103

I think we will need to bump the major version to indicate to users the breaking nature of removing these two fields from the config maps. The upgrade path should be pretty simple, even though it is a breaking change.

I plan to test this PR a bit more before merging it.