### PR TITLE
Fix configMap key value template

### DIFF
--- a/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-configmap.yaml
@@ -43,8 +43,7 @@ data:
     {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
       {{- end }}
     {{- end }}
-{{ toYaml .Values.autoRecovery.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  BOOKIE_MEM: {{ .Values.autoRecovery.configData.BOOKIE_MEM }}
-  BOOKIE_GC: {{ .Values.autoRecovery.configData.BOOKIE_GC }}
+{{- range $key, $val := $.Values.autoRecovery.configData }}
+  {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
+{{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/bastion/bastion-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion/bastion-configmap.yaml
@@ -38,8 +38,7 @@ data:
   {{- else }}
   tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
-{{ toYaml .Values.bastion.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.bastion.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.bastion.configData.PULSAR_GC }}
+{{- range $key, $val := $.Values.bastion.configData }}
+  {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
+{{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-configmap.yaml
@@ -68,7 +68,6 @@ data:
   PULSAR_PREFIX_bookkeeperTLSTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
   {{- end }}
-{{ toYaml .Values.bookkeeper.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  BOOKIE_MEM: {{ .Values.bookkeeper.configData.BOOKIE_MEM }}
-  BOOKIE_GC: {{ .Values.bookkeeper.configData.BOOKIE_GC }}
+{{- range $key, $val := $.Values.bookkeeper.configData }}
+  {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -218,8 +218,7 @@ data:
   {{- end }}
 {{- end }}
 {{- end }}
-{{ toYaml .Values.broker.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.broker.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.broker.configData.PULSAR_GC }}
+{{- range $key, $val := $.Values.broker.configData }}
+  {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
+{{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -218,8 +218,7 @@ data:
   {{- end }}
 {{- end }}
 {{- end }}
-{{ toYaml .Values.brokerSts.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.brokerSts.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.brokerSts.configData.PULSAR_GC }}
+{{- range $key, $val := $.Values.brokerSts.configData }}
+  {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
+{{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-extra-configmap.yaml
@@ -38,8 +38,7 @@ data:
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
   brokerClientAuthenticationParameters: "file:///pulsar/token-superuser/superuser.jwt"
   {{- end }}
-{{ toYaml .Values.function.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.function.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.function.configData.PULSAR_GC }}
+{{- range $key, $val := $.Values.function.configData }}
+  {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
+{{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -117,10 +117,9 @@ data:
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
   brokerClientAuthenticationParameters: "file:///pulsar/token-proxy/proxy.jwt"
 {{- end }}
-{{ toYaml .Values.proxy.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.proxy.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.proxy.configData.PULSAR_GC }}
+{{- range $key, $val := $.Values.proxy.configData }}
+  {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
+{{- end }}
 {{- end }}
 {{- if .Values.proxy.extensions.enabled }}
   PULSAR_PREFIX_proxyExtensionsDirectory: "{{ .Values.proxy.extensions.directory }}"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -75,8 +75,7 @@ data:
   {{- end }}
   {{- end }}
 {{- end }}
-{{ toYaml .Values.proxy.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.proxy.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.proxy.configData.PULSAR_GC }}
+{{- range $key, $val := $.Values.proxy.configData }}
+  {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
+{{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-configmap.yaml
@@ -37,8 +37,7 @@ data:
   sslQuorum: "true"
   PULSAR_PREFIX_sslQuorum: "true"
   {{- end }}
-{{ toYaml .Values.zookeepernp.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.zookeepernp.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.zookeepernp.configData.PULSAR_GC }}
+{{- range $key, $val := $.Values.zookeepernp.configData }}
+  {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
+{{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -36,7 +36,6 @@ data:
   sslQuorum: "true"
   PULSAR_PREFIX_sslQuorum: "true"
   {{- end }}
-{{ toYaml .Values.zookeeper.configData | indent 2 }}
-  # Workaround for double-quoted values in old values files
-  PULSAR_MEM: {{ .Values.zookeeper.configData.PULSAR_MEM }}
-  PULSAR_GC: {{ .Values.zookeeper.configData.PULSAR_GC }}
+{{- range $key, $val := $.Values.zookeeper.configData }}
+  {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
+{{- end }}


### PR DESCRIPTION
# Overview

In this commit, based on [issue 103](https://github.com/datastax/pulsar-helm-chart/issues/103#issuecomment-999931038) I suggested to omit the `toYaml` and instead use key value iteration to produce the configMap configData.

This should solve the issue of duplicated keys in the configMap and also keep backward compatibility with values provided with two sets of double quotes.

@michaeljmarshall I wasn't sure if I have to bump the Chart's version or is that something your automation takes care of.

# Tested Values
I have tested using `helm template .` while testing different ways of configuring the values for configData:

Option 1:
```yaml
zookeeper:
  configData:
    PULSAR_MEM: >
      -Xms1g
      -Xmx1g
      -Dcom.sun.management.jmxremote
      -Djute.maxbuffer=10485760
    PULSAR_GC: >
      -XX:+UseG1GC
    PULSAR_LOG_LEVEL: "info"
    PULSAR_LOG_ROOT_LEVEL: "info"
    PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true -Dpulsar.log.root.level=info"
```
Option 2:
```yaml
zookeeper:
  configData:
    PULSAR_MEM: "\"-Xms1g -Xmx1g -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760\""
    PULSAR_GC: "\"-XX:+UseG1GC\""
    PULSAR_LOG_LEVEL: "info"
    PULSAR_LOG_ROOT_LEVEL: "info"
    PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true -Dpulsar.log.root.level=info"
```
Option 3 (should be the same for single-quotes):
```yaml
zookeeper:
  configData:
    PULSAR_MEM: "-Xms1g -Xmx1g -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760"
    PULSAR_GC: "-XX:+UseG1GC"
    PULSAR_LOG_LEVEL: "info"
    PULSAR_LOG_ROOT_LEVEL: "info"
    PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true -Dpulsar.log.root.level=info"
```
Option 4:
```yaml
zookeeper:
  configData:
    PULSAR_MEM: -Xms1g -Xmx1g -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760
    PULSAR_GC: -XX:+UseG1GC
    PULSAR_LOG_LEVEL: "info"
    PULSAR_LOG_ROOT_LEVEL: "info"
    PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true -Dpulsar.log.root.level=info"
```

# Outputs
I have tested the output of the configMaps that could be produced by the chart:

pulsar-bastion:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "pulsar-bastion"
  namespace: monitoring
  labels:
    app: pulsar
    chart: pulsar-2.0.10
    release: RELEASE-NAME
    heritage: Helm
    component: bastion
    cluster: pulsar
data:
  tlsTrustCertsFilePath: "/etc/ssl/certs/ca-certificates.crt"
  PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info"
  PULSAR_GC: "-XX:+UseG1GC"
  PULSAR_LOG_LEVEL: "info"
  PULSAR_LOG_ROOT_LEVEL: "info"
  PULSAR_MEM: "-XX:+ExitOnOutOfMemoryError"
```
 
pulsar-broker:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "pulsar-broker"
  namespace: monitoring
  labels:
    app: pulsar
    chart: pulsar-2.0.10
    release: RELEASE-NAME
    heritage: Helm
    component: broker
    cluster: pulsar
data:
  zookeeperServers:
    pulsar-zookeeper-ca:2181
  configurationStoreServers:
    pulsar-zookeeper-ca:2181
  clusterName: pulsar
  allowAutoTopicCreationType: "non-partitioned"
  PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info"
  PULSAR_GC: "-XX:+UseG1GC"
  PULSAR_LOG_LEVEL: "info"
  PULSAR_LOG_ROOT_LEVEL: "info"
  PULSAR_MEM: "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError"
  backlogQuotaDefaultRetentionPolicy: "producer_exception"
  brokerDeduplicationEnabled: "false"
  exposeConsumerLevelMetricsInPrometheus: "false"
  exposeTopicLevelMetricsInPrometheus: "true"
```

pulsar-brokerSts:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "pulsar-brokersts"
  namespace: monitoring
  labels:
    app: pulsar
    chart: pulsar-2.0.10
    release: RELEASE-NAME
    heritage: Helm
    component: brokersts
    cluster: pulsar
data:
  zookeeperServers:
    pulsar-zookeeper-ca:2181
  configurationStoreServers:
    pulsar-zookeeper-ca:2181
  clusterName: pulsar
  allowAutoTopicCreationType: "non-partitioned"
  PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info"
  PULSAR_GC: "-XX:+UseG1GC"
  PULSAR_LOG_LEVEL: "info"
  PULSAR_LOG_ROOT_LEVEL: "info"
  PULSAR_MEM: "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -Dio.netty.leakDetectionLevel=disabled -Dio.netty.recycler.linkCapacity=1024 -XX:+ExitOnOutOfMemoryError"
  backlogQuotaDefaultRetentionPolicy: "producer_exception"
  brokerDeduplicationEnabled: "false"
  exposeConsumerLevelMetricsInPrometheus: "false"
  exposeTopicLevelMetricsInPrometheus: "true"
```

pulsar-function-extra:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "pulsar-function-extra"
  namespace: monitoring
  labels:
    app: pulsar
    chart: pulsar-2.0.10
    release: RELEASE-NAME
    heritage: Helm
    component: function
    cluster: pulsar
data:
  PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info"
  PULSAR_GC: "-XX:+UseG1GC"
  PULSAR_LOG_LEVEL: "info"
  PULSAR_LOG_ROOT_LEVEL: "info"
  PULSAR_MEM: "-Xms2g -Xmx2g -XX:MaxDirectMemorySize=2g -XX:+ExitOnOutOfMemoryError"
```

pulsar-proxy:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "pulsar-proxy"
  namespace: monitoring
  labels:
    app: pulsar
    chart: pulsar-2.0.10
    release: RELEASE-NAME
    heritage: Helm
    component: proxy
    cluster: pulsar
data:
  brokerServiceURL: "pulsar://pulsar-broker:6650"
  brokerServiceURLTLS: "pulsar+ssl://pulsar-broker:6651"
  brokerWebServiceURL: "http://pulsar-broker:8080"
  brokerWebServiceURLTLS: "https://pulsar-broker:8443"
  zookeeperServers:
    pulsar-zookeeper-ca:2181
  configurationStoreServers:
    pulsar-zookeeper-ca:2181
  PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info"
  PULSAR_GC: "-XX:+UseG1GC"
  PULSAR_LOG_LEVEL: "info"
  PULSAR_LOG_ROOT_LEVEL: "info"
  PULSAR_MEM: "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g"
  numHttpServerThreads: "10"
```

pulsar-proxy-ws
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "pulsar-proxy-ws"
  namespace: monitoring
  labels:
    app: pulsar
    chart: pulsar-2.0.10
    release: RELEASE-NAME
    heritage: Helm
    component: proxy
    cluster: pulsar
data:
  brokerServiceUrl: "pulsar://pulsar-broker:6650"
  brokerServiceUrlTls: "pulsar+ssl://pulsar-broker:6651"
  serviceUrl: "http://pulsar-broker:8080"
  serviceUrlTls: "https://pulsar-broker:8443"
  zookeeperServers:
    "pulsar-zookeeper-ca:2181"
  configurationStoreServers:
    "pulsar-zookeeper-ca:2181"
  clusterName: pulsar
  webServicePort: "8000"
  PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info"
  PULSAR_GC: "-XX:+UseG1GC"
  PULSAR_LOG_LEVEL: "info"
  PULSAR_LOG_ROOT_LEVEL: "info"
  PULSAR_MEM: "-Xms1g -Xmx1g -XX:MaxDirectMemorySize=1g"
  numHttpServerThreads: "10"
```

pulsar-zookeepernp
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "pulsar-zookeepernp"
  namespace: monitoring
  labels:
    app: pulsar
    chart: pulsar-2.0.10
    release: RELEASE-NAME
    heritage: Helm
    component: zookeepernp
    cluster: pulsar
data:
  PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true -Dpulsar.log.root.level=info"
  PULSAR_GC: "-XX:+UseG1GC"
  PULSAR_LOG_LEVEL: "info"
  PULSAR_LOG_ROOT_LEVEL: "info"
  PULSAR_MEM: "-Xms1g -Xmx1g -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760"
```

pulsar-zookeeper:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: "pulsar-zookeeper"
  namespace: monitoring
  labels:
    app: pulsar
    chart: pulsar-2.0.10
    release: RELEASE-NAME
    heritage: Helm
    component: zookeeper
    cluster: pulsar
data:
  PULSAR_EXTRA_OPTS: "-Dzookeeper.tcpKeepAlive=true -Dzookeeper.clientTcpKeepAlive=true -Dpulsar.log.root.level=info"
  PULSAR_GC: "-XX:+UseG1GC"
  PULSAR_LOG_LEVEL: "info"
  PULSAR_LOG_ROOT_LEVEL: "info"
  PULSAR_MEM: "-Xms1g -Xmx1g -Dcom.sun.management.jmxremote -Djute.maxbuffer=10485760"
```