### PR TITLE
Drop references to TLSv1.1 and introduce the usage of TLSv1.3 besides keeping TLSv1.2

### DIFF
--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -176,7 +176,7 @@ data:
             listen 8443 ssl;
             ssl_certificate /certs/tls.crt;
             ssl_certificate_key /certs/tls.key;
-            ssl_protocols TLSv1.1 TLSv1.2 TLSv1.3;
+            ssl_protocols TLSv1.2 TLSv1.3;
             {{- end }}
 
       }

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -101,7 +101,7 @@ data:
   {{- else }}
   tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
-  tlsProtocols: "TLSv1.2,TLSv1.1"
+  tlsProtocols: "TLSv1.3,TLSv1.2"
   brokerServicePortTls: "6651"
   brokerClientTlsEnabled: "true"
   webServicePortTls: "8443"

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -101,7 +101,7 @@ data:
   {{- else }}
   tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
-  tlsProtocols: "TLSv1.2,TLSv1.1"
+  tlsProtocols: "TLSv1.3,TLSv1.2"
   brokerServicePortTls: "6651"
   brokerClientTlsEnabled: "true"
   webServicePortTls: "8443"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -82,7 +82,7 @@ data:
   {{- else }}
   tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
   {{- end }}
-  tlsProtocols: "TLSv1.2,TLSv1.1"
+  tlsProtocols: "TLSv1.3,TLSv1.2"
   {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled}}
   brokerClientTrustCertsFilePath: /pulsar/certs/ca.crt
   {{- else }}


### PR DESCRIPTION
- The usage of TLSv1.1 isn't recommended at all.
- Pulsar 2.8.x supports TLSv1.3. 
- Configure TLS to use TLSv1.3 and TLSv1.2