### PR TITLE
Restart Zookeeper metadata pod on failure

### DIFF
--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
@@ -81,5 +81,5 @@ spec:
               {{- end }}
               --web-service-url http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}:8080/ \
               --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}:6650/;
-      restartPolicy: Never
+      restartPolicy: OnFailure
 {{- end }}


### PR DESCRIPTION
When the zookeeper metadata pod fails currently, it will leave a pod in ERROR state. This pod then needs to be manually cleaned up. The errors happen because of race conditions or potential network issues during start up. It is cleaner to just restart on failure, since the job will spawn another pod if the first pod goes to ERROR state.