### PR TITLE
Bump Cert-Manager Helm Chart from 1.1.x to 1.5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Note: With message/state persistence disabled, the cluster will not survive a re
 * dev-values-tls.yaml. Development environment with self-signed certificate created by cert-manager. You need to install the cert-manager CRDs before installing the Helm chart. The chart will install the cert-manager application.
 
 ```
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.crds.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.crds.yaml
 helm install pulsar -f dev-values-tls.yaml datastax-pulsar/pulsar
 ```
 

--- a/aws-customer-docs.md
+++ b/aws-customer-docs.md
@@ -15,7 +15,7 @@ Reference: https://docs.cert-manager.io
 
 * Install the Cert-Manager CustomResourceDefinition resources
 ```
-kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.crds.yaml
 ```
 
 * Create the namespace for Cert-Manager
@@ -38,7 +38,7 @@ helm repo update
 helm install \
   --name cert-manager \
   --namespace cert-manager \
-  --version v0.12.0 \
+  --version v1.5.5 \
   jetstack/cert-manager
 ```
 
@@ -99,7 +99,7 @@ kubectl apply -f aws_key_secret.yaml
 Create a ClusterIssuer that includes the IAM access key and references the secret:
 
 ```
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-production
@@ -136,7 +136,7 @@ kubectl apply -f letsencrypt-production-aws.yaml
 Create a certificate resource file like this:
 
 ```
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: <insert-name-for-certificate>

--- a/helm-chart-sources/pulsar/Chart.yaml
+++ b/helm-chart-sources/pulsar/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   condition: kube-prometheus-stack.enabled
 - name: cert-manager
-  version: v1.1.x
+  version: v1.5.x
   repository: https://charts.jetstack.io
   condition: cert-manager.enabled
 - name: keycloak


### PR DESCRIPTION
Fixes https://github.com/datastax/pulsar-helm-chart/issues/58

## Motivation

The latest version of Cert Manager is 1.6.x. However, going from 1.5 to 1.6 appears to have breaking changes in the CRDs. Since we're planning on doing a 3.0.0 release soon, I think we should only ship with 1.6 once we're ready to cut the 3.0.0 release.

Note that going from 1.1 to 1.2 appears to have some potential impacts on installations. Please review the upgrade notes from Cert Manager to ensure a correct upgrade.

## Relevant upgrade notes from the Cert Manager Project

- https://cert-manager.io/docs/installation/upgrading/upgrading-1.1-1.2/
- https://cert-manager.io/docs/installation/upgrading/upgrading-1.2-1.3/
- https://cert-manager.io/docs/installation/upgrading/upgrading-1.3-1.4/
- https://cert-manager.io/docs/installation/upgrading/upgrading-1.4-1.5/