### PR TITLE
Ensure PodDisruptionBudget renders correctly for each k8s version

### DIFF
--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-pdb.yaml
@@ -16,7 +16,7 @@
 #
 
 {{- if .Values.bookkeeper.pdb.usePolicy }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-pdb.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.extra.broker }}
 {{- if .Values.broker.pdb.usePolicy }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-pdb.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.extra.brokerSts }}
 {{- if .Values.brokerSts.pdb.usePolicy }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/helm-chart-sources/pulsar/templates/function/function-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-pdb.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.extra.function }}
 {{- if .Values.function.pdb.usePolicy }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-pdb.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.extra.proxy }}
 {{- if .Values.proxy.pdb.usePolicy }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-pdb.yaml
@@ -17,7 +17,7 @@
 
 {{- if .Values.extra.zookeepernp }}
 {{- if .Values.zookeepernp.pdb.usePolicy }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-pdb.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-pdb.yaml
@@ -16,7 +16,7 @@
 #
 
 {{- if .Values.zookeeper.pdb.usePolicy }}
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if semverCompare ">=1.21-0" .Capabilities.KubeVersion.Version }}
 apiVersion: policy/v1
 {{- else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
## Motivation

As pointed out in https://github.com/apache/pulsar-helm-chart/pull/183#discussion_r777770205, the `.Capabilities.ApiVersion.Has` feature does not render correctly when using the `helm template` feature. Since some users first template the manifests and then apply them, we need to make sure that the chart works correctly for template. 

## Verification

I verified that the template feature renders these as expected. Here are my results:

```shell
$ helm template test -f examples/dev-values-tls.yaml helm-chart-sources/pulsar --kube-version "v1.21.0" | grep -a1 "kind: PodDisruptionBudget"
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
--
--
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
--
--
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
--
--
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
--
--
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
$ helm template test -f examples/dev-values-tls.yaml helm-chart-sources/pulsar --kube-version "v1.20.0" | grep -a1 "kind: PodDisruptionBudget"
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
--
--
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
--
--
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
--
--
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
--
--
apiVersion: policy/v1beta1
kind: PodDisruptionBudget
metadata:
```

CI will verify that `helm install` works as expected too.