### PR TITLE
Monitor Autorecovery Pods

### DIFF
--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1389,7 +1389,9 @@ autoRecovery:
   #         values:
   #         - bookkeeper
   #     topologyKey: "kubernetes.io/hostname"
-  annotations: {}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "8000"
   tolerations: []
   gracePeriod: 60
   resources:


### PR DESCRIPTION
Fixes: #72 

This is a temporary fix to include auto-recovery pods in the prometheus metrics scrapes. When we upgrade prometheus (which should be soon), we will switch to pod monitors.