### PR TITLE
Use Parallel podManagementPolicy by default for StatefulSets

### DIFF
--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -430,7 +430,7 @@ zookeeper:
   replicaCount: 3
   updateStrategy:
     type: RollingUpdate
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   # nodeAffinity:
@@ -520,7 +520,7 @@ zookeepernp:
   replicaCount: 0
   updateStrategy:
     type: RollingUpdate
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   # nodeAffinity:
@@ -598,7 +598,7 @@ bookkeeper:
   replicaCount: 3
   updateStrategy:
     type: RollingUpdate
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   # nodeAffinity:
@@ -959,7 +959,7 @@ function:
   usePython3: false
   updateStrategy:
     type: RollingUpdate
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   probe:
     enabled: true
     port: 6750


### PR DESCRIPTION
## Motivation

When we initialize a Pulsar cluster, it takes a while to scale up the bookies and zookeepers. Since k8s 1.17, we can configure the stateful set so that it deploys all pods at once. This will speed up cluster initialization as well as cluster scale ups.