### PR TITLE
Increase default initialDelaySeconds probes for Zookeeper

### DIFF
--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -449,7 +449,7 @@ zookeeper:
   gracePeriod: 60
   probe:
     enabled: true
-    initial: 10
+    initial: 20
     period: 30
     timeout: 5
   resources:
@@ -539,7 +539,7 @@ zookeepernp:
   gracePeriod: 60
   probe:
     enabled: true
-    initial: 10
+    initial: 20
     period: 30
     timeout: 5
   resources:


### PR DESCRIPTION
- increase from 10 to 20 seconds to workaround ZOOKEEPER-3988