### PR TITLE
[s3 gateway] use fixed tag version instead of 'latest'

### DIFF
--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -334,7 +334,7 @@ image:
   tardigrade:
     repository: storjlabs/gateway
     pullPolicy: IfNotPresent
-    tag: latest
+    tag: 981f92a-v1.20.0-go1.17.5
   pulsarHeartbeat:
     repository: datastax/pulsar-heartbeat
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Using a fixed version makes the deploy process more reproducible

Currently the 'latest' version points to 981f92a-v1.20.0-go1.17.5 (I compared the digest)
see here https://hub.docker.com/r/storjlabs/gateway-mt/tags