### PR TITLE
[Pulsar SQL] Use servicePort name for ingress target port

### DIFF
--- a/helm-chart-sources/pulsar/templates/pulsarSql/ingress.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/ingress.yaml
@@ -39,6 +39,6 @@ spec:
           - path: /
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarSQL.component }}"
-              servicePort: 8080
+              servicePort: "http-coord"
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes: #132 

By using the name of the target port, this will work for all configured values of `.Values.pulsarSQL.server.config.http.port`.