### PR TITLE
Wrap Zookeeper probe script with timeout command

### DIFF
--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-statefulset.yaml
@@ -153,6 +153,8 @@ spec:
         readinessProbe:
           exec:
             command:
+            - timeout
+            - "{{ .Values.zookeepernp.probe.timeout }}"
             - "bin/pulsar-zookeeper-ruok.sh"
           initialDelaySeconds: {{ .Values.zookeepernp.probe.initial }}
           periodSeconds: {{ .Values.zookeepernp.probe.period }}
@@ -160,6 +162,8 @@ spec:
         livenessProbe:
           exec:
             command:
+            - timeout
+            - "{{ .Values.zookeepernp.probe.timeout }}"
             - "bin/pulsar-zookeeper-ruok.sh"
           initialDelaySeconds: {{ .Values.zookeepernp.probe.initial }}
           periodSeconds: {{ .Values.zookeepernp.probe.period }}

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -162,6 +162,8 @@ spec:
         readinessProbe:
           exec:
             command:
+            - timeout
+            - "{{ .Values.zookeeper.probe.timeout }}"
             - "bin/pulsar-zookeeper-ruok.sh"
           initialDelaySeconds: {{ .Values.zookeeper.probe.initial }}
           periodSeconds: {{ .Values.zookeeper.probe.period }}
@@ -169,6 +171,8 @@ spec:
         livenessProbe:
           exec:
             command:
+            - timeout
+            - "{{ .Values.zookeeper.probe.timeout }}"
             - "bin/pulsar-zookeeper-ruok.sh"
           initialDelaySeconds: {{ .Values.zookeeper.probe.initial }}
           periodSeconds: {{ .Values.zookeeper.probe.period }}


### PR DESCRIPTION
### Motivation

Run Zookeeper probes with timeout command so that the probe doesn't continue running indefinitely.

It seems that the probe will get stuck because of https://issues.apache.org/jira/browse/ZOOKEEPER-3988 / https://github.com/apache/pulsar/issues/11070 .

### Modifications

- wrap Zookeeper probe script with [timeout](https://www.gnu.org/software/coreutils/timeout) (included in Docker image, [timeout](https://www.gnu.org/software/coreutils/timeout) is part of gnu coreutils package)


### Additional context

This PR resolves the issue with Kubernetes <1.20
"Before Kubernetes 1.20, the field timeoutSeconds was not respected for exec probes: probes continued running indefinitely, even past their configured deadline, until a result was returned."
described in https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes

- #74 already fixed the issue for Kubernetes 1.20+
