### PR TITLE
Make spec.loadBalancerIP configurable for load balancer services

### DIFF
--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
@@ -32,6 +32,9 @@ metadata:
 {{ toYaml .Values.pulsarAdminConsole.annotations | indent 4 }}
 spec:
   type: {{ .Values.pulsarAdminConsole.service.type }}
+  {{- if .Values.pulsarAdminConsole.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.pulsarAdminConsole.service.loadBalancerIP }}
+  {{- end }}
   ports:
 {{ toYaml .Values.pulsarAdminConsole.service.ports | indent 2 }}
   selector:

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-service.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-service.yaml
@@ -41,6 +41,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.proxy.service.type }}
+  {{- if .Values.proxy.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.proxy.service.loadBalancerIP }}
+  {{- end }}
   ports:
   {{- if .Values.proxy.service.autoPortAssign.enabled }}
 {{ include "pulsar.proxyAutoPort" . | indent 2 }}
@@ -77,6 +80,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.proxy.extraService.type }}
+  {{- if .Values.proxy.extraService.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.proxy.extraService.loadBalancerIP }}
+  {{- end }}
   ports:
   {{- if .Values.proxy.extraService.autoPortAssign.enabled }}
 {{ include "pulsar.proxyAutoPort" . | indent 2 }}

--- a/helm-chart-sources/pulsar/templates/pulsarSql/service.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/service.yaml
@@ -27,6 +27,9 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   type: {{ .Values.pulsarSQL.service.type }}
+  {{- if .Values.pulsarSQL.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.pulsarSQL.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.pulsarSQL.server.config.http.port }}
       targetPort: http-coord

--- a/helm-chart-sources/pulsar/templates/tardigrade/service.yaml
+++ b/helm-chart-sources/pulsar/templates/tardigrade/service.yaml
@@ -25,6 +25,9 @@ metadata:
     app: {{ .Release.Name }}-tardigrade-gateway
 spec:
   type: {{ .Values.tardigrade.service.type }}
+  {{- if .Values.tardigrade.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.tardigrade.service.loadBalancerIP }}
+  {{- end }}
   selector:
     app: {{ .Release.Name }}-tardigrade-gateway
   ports:


### PR DESCRIPTION
Fixes: #139 

I updated the services that are expected to be load balancers. I did not update the broker service, since that won't work for a single load balancer.