### PR TITLE
Enable annotation configuration for broker and pulsar sql services

### DIFF
--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-service.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-service.yaml
@@ -29,6 +29,9 @@ metadata:
     component: {{ .Values.broker.component }}
     cluster: {{ template "pulsar.fullname" . }}
   annotations:
+  {{- if .Values.broker.service.annotations }}
+{{ toYaml .Values.broker.service.annotations | indent 4 }}
+  {{- end }}
 {{- if .Values.extra.dnsOnBroker }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.dnsName }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-service.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-service.yaml
@@ -29,6 +29,9 @@ metadata:
     component: {{ .Values.brokerSts.component }}
     cluster: {{ template "pulsar.fullname" . }}
   annotations:
+  {{- if .Values.brokerSts.service.annotations }}
+{{ toYaml .Values.brokerSts.service.annotations | indent 4 }}
+  {{- end }}
 {{- if .Values.extra.dnsOnBroker }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.dnsName }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/pulsarSql/service.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/service.yaml
@@ -25,6 +25,10 @@ metadata:
     chart: {{ template "presto.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.pulsarSQL.service.annotations }}
+  annotations:
+{{ toYaml .Values.pulsarSQL.service.annotations | indent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.pulsarSQL.service.type }}
   {{- if .Values.pulsarSQL.service.loadBalancerIP }}


### PR DESCRIPTION
Fixes: #131 

Enable annotations for the broker deployment, broker statefulset, and pulsar sql services.