### PR TITLE
Fix Pulsar Admin Console service annotation reference

### DIFF
--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
@@ -30,7 +30,6 @@ metadata:
     cluster: {{ template "pulsar.fullname" . }}
   annotations:
 {{ toYaml .Values.pulsarAdminConsole.service.annotations | indent 4 }}
-# TODO remove this deprecated field on the next major version bump
 {{ toYaml .Values.pulsarAdminConsole.annotations | indent 4 }}
 spec:
   type: {{ .Values.pulsarAdminConsole.service.type }}

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
@@ -30,7 +30,6 @@ metadata:
     cluster: {{ template "pulsar.fullname" . }}
   annotations:
 {{ toYaml .Values.pulsarAdminConsole.service.annotations | indent 4 }}
-{{ toYaml .Values.pulsarAdminConsole.annotations | indent 4 }}
 spec:
   type: {{ .Values.pulsarAdminConsole.service.type }}
   {{- if .Values.pulsarAdminConsole.service.loadBalancerIP }}

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-service.yaml
@@ -29,6 +29,8 @@ metadata:
     component: {{ .Values.pulsarAdminConsole.component }}
     cluster: {{ template "pulsar.fullname" . }}
   annotations:
+{{ toYaml .Values.pulsarAdminConsole.service.annotations | indent 4 }}
+# TODO remove this deprecated field on the next major version bump
 {{ toYaml .Values.pulsarAdminConsole.annotations | indent 4 }}
 spec:
   type: {{ .Values.pulsarAdminConsole.service.type }}


### PR DESCRIPTION
Fixes: #129 

As the issue identifies, we were using the wrong value for the annotations on the Pulsar Admin Console service. Because some users might have been using the `.Values.pulsarAdminConsole.annotations` as a work around, I am going to leave it there until our next major release. Then, we'll remove the deprecated reference.