### PR TITLE
Increase Zookeeper probe timeouts

### DIFF
--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -453,7 +453,7 @@ zookeeper:
     enabled: true
     initial: 20
     period: 30
-    timeout: 5
+    timeout: 30
   resources:
     requests:
       memory: 1Gi
@@ -543,7 +543,7 @@ zookeepernp:
     enabled: true
     initial: 20
     period: 30
-    timeout: 5
+    timeout: 30
   resources:
     requests:
       memory: 1Gi


### PR DESCRIPTION
- 5 seconds seems to be too short a probe timeout on a system with low resources, such as in CI