### PR TITLE
function uploadBuiltinSinksSources

### DIFF
--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -57,6 +57,7 @@ data:
       {{- end }}
     {{- end }}
     zooKeeperSessionTimeoutMillis: 30000
+    uploadBuiltinSinksSources: "{{ Values.function.uploadBuiltinSinksSources }}"
     pulsarFunctionsCluster: "{{ template "pulsar.fullname" . }}"
     workerId: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"
     workerHostname: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1035,6 +1035,8 @@ function:
   #   mainContainerStartupCmd: "cp -f /connectors/pulsar-connectors/* /pulsar/connectors"
 
   authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
+  # upload false means the connector jar will not uploaded from bookie but from the same version as function worker
+  uploadBuiltinSinksSources: "false"
 
   ## When adding custom properties to configure a function worker, the values must be supplied here. Normal config
   ## is read in to the WorkerConfig fields. Custom configuration (for fields that are not in the WorkerConfig class)


### PR DESCRIPTION
A configuration allows the connector jar to be updated to the same version as the function worker jar when the connector is restarted. This happens when uploadBuiltinSinksSources = false

When it's set true, the jar will be uploaded from the bookie. This means upgrading the function worker, the connector jar won't be upgraded with restarting