### PR TITLE
Update Ingress API Version (`extensions/v1beta1` -> `networking.k8s.io/v1`)

### DIFF
--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -108,6 +108,8 @@ grafanaDashboards:
 
 pulsarAdminConsole:
   replicaCount: 1
+  ingress:
+    enabled: true
 
 kube-prometheus-stack:
   enabled: false

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-ingress.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-ingress.yaml
@@ -17,7 +17,11 @@
 
 {{- if .Values.extra.pulsarAdminConsole }}
 {{- if .Values.pulsarAdminConsole.ingress.enabled }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}"
@@ -37,13 +41,31 @@ spec:
       http:
         paths:
           - path: /
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}"
               servicePort: 8080
+            {{- else }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}"
+                port: 
+                  number: 8080
+            {{- end }}
           - path: /ws/
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}"
               servicePort: 8080
+            {{- else }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}"
+                port: 
+                  number: 8080
+            {{- end }}
   {{- if and .Values.enableTls .Values.pulsarAdminConsole.ingress.enableTls}}
   tls:
   - hosts:

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ingress.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ingress.yaml
@@ -16,7 +16,11 @@
 #
 
 {{- if .Values.proxy.ingress.enabled }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
@@ -42,6 +46,7 @@ spec:
       http:
         paths:
           - path: /
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
               {{- if .Values.enableTls }}
@@ -49,8 +54,21 @@ spec:
               {{- else }}
               servicePort: 8080
               {{- end }}
+            {{- else }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+                port: 
+                  {{- if .Values.enableTls }}
+                  number: 8443
+                  {{- else }}
+                  number: 8080
+                  {{- end }}
+            {{- end }}
           {{- if .Values.proxy.ingress.enableWebSocket }}
           - path: /ws
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
               {{- if .Values.enableTls }}
@@ -58,15 +76,37 @@ spec:
               {{- else }}
               servicePort: 8000
               {{- end }}
+            {{- else }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+                port:
+                  {{- if .Values.enableTls }}
+                  number: {{ .Values.proxy.ingress.wssPortOnProxy }}
+                  {{- else }}
+                  number: 8000
+                  {{- end }}
+            {{- end }}
           {{- end }}
           {{- if .Values.proxy.ingress.enableBurnell }}
           - path: /br
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
               servicePort: 8964
+            {{- else }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+                port: 
+                  number: 8964
+            {{- end }}
           {{- end }}
           {{- if .Values.broker.ingress.enabled }}
           - path: /broker
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
               {{- if .Values.enableTls }}
@@ -74,5 +114,17 @@ spec:
               {{- else }}
               servicePort: 8080
               {{- end }}
+            {{- else }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+                port:
+              {{- if .Values.enableTls }}
+                number: 8443
+              {{- else }}
+              number: 8080
+              {{- end }}
+            {{- end }}
           {{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/pulsarSql/ingress.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/ingress.yaml
@@ -52,7 +52,6 @@ spec:
               service:
                 name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarSQL.component }}"
                 port: 
-                  number: 8080
                   name: "http-coord"
             {{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/pulsarSql/ingress.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/ingress.yaml
@@ -17,7 +17,11 @@
 
 {{- if .Values.extra.pulsarSQL }}
 {{- if .Values.pulsarSQL.ingress.enabled }}
+{{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
 apiVersion: extensions/v1beta1
+{{- else }}
+apiVersion: networking.k8s.io/v1
+{{- end }}
 kind: Ingress
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarSQL.component }}"
@@ -37,8 +41,17 @@ spec:
       http:
         paths:
           - path: /
+            {{- if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version }}
             backend:
               serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarSQL.component }}"
               servicePort: 8080
+            {{- else }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarSQL.component }}"
+                port: 
+                  number: 8080
+            {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Addresses #140 .

The change was done accordingly to the k8s [deprecation guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122) and taking as an example the apache [pulsar helmchart analogous change](https://github.com/apache/pulsar-helm-chart/commit/83bb8bd6).

The correctness of the change was only syntactically checked by the following command run against k8s server versions v1.18.20 and v1.19.16. The helm version used for both runs is v3.6.3.

```
helm install "pulsar" helm-chart-sources/pulsar/ --namespace pulsar --create-namespace --values examples/dev-values.yaml --set "kube-prometheus-stack.enabled=false,extra.pulsarSQL=true,pulsarSQL.ingress.enabled=true,extra.pulsarAdminConsole=true,pulsarAdminConsole.ingress.enabled=true,proxy.ingress.enabled=true" --dry-run --debug | grep -A 30 -B 2 "kind: Ingress"
```

It should be noted that `kube-prometheus-stack.enabled=false` was necessary in order to avoid the error:

```
Error: unable to build kubernetes objects from release manifest: [unable to recognize no matches for kind "PrometheusRule" in version "monitoring.coreos.com/v1", unable to recognize "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"]
helm.go:88: [debug] [unable to recognize no matches for kind "PrometheusRule" in version "monitoring.coreos.com/v1", unable to recognize "": no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"]
```