### PR TITLE
User ClusterIP services for test

### DIFF
--- a/helm-chart-sources/pulsar/ci/test-notls-values.yaml
+++ b/helm-chart-sources/pulsar/ci/test-notls-values.yaml
@@ -102,12 +102,15 @@ proxy:
   service:
     autoPortAssign:
       enabled: true
+    type: ClusterIP
 
 grafanaDashboards:
   enabled: false
 
 pulsarAdminConsole:
   replicaCount: 1
+  service:
+    type: ClusterIP
 
 kube-prometheus-stack:
   enabled: false


### PR DESCRIPTION
In our current test logs,we're failing to complete the helm deployment because of this error:

```
ready.go:258: [debug] Service does not have load balancer ingress IP address: pulsar-lzg9asf1t7/pulsar-adminconsole
```

We don't need to test with load balancers. Instead, use ClusterIP to ensure that the targets properly come up