### PR TITLE
Remove invalid calls to "bin/apply-config-from-env.py conf/bkenv.sh"

### DIFF
--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -138,7 +138,6 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/bookkeeper.conf &&
-          bin/apply-config-from-env.py conf/bkenv.sh &&
           bin/bookkeeper shell metaformat --nonInteractive || true;
         envFrom:
         - configMapRef:
@@ -173,7 +172,6 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/bookkeeper.conf &&
-          bin/apply-config-from-env.py conf/bkenv.sh &&
           {{- if and .Values.enableTls .Values.tls.bookkeeper.enabled }}
           openssl pkcs8 -topk8 -inform PEM -outform PEM -in /pulsar/certs/tls.key -out /pulsar/tls-pk8.key -nocrypt &&
           {{- end }}


### PR DESCRIPTION
- this is obsolete after apache/pulsar#6579, apache/pulsar#4105 and apache/pulsar#5892
  changes. 
  - `apply-config-from-env.py` doesn't properly handle replacements for shell scripts and it's not necessary to use it.