### PR TITLE
Remove Metal LB from test environment

### DIFF
--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -69,11 +69,6 @@ create_kind_cluster() {
 
     echo 'Cluster ready!'
     echo
-
-    if [ "$node_count" -eq 0 ]; then
-        echo 'Setup metallb in k8s'
-        setup_load_balancer
-    fi
 }
 
 
@@ -102,19 +97,6 @@ pull_and_cache_docker_images() {
         kind load docker-image -v 1 --name "$CLUSTER_NAME" --nodes "$nodes" "$image"
     done
 }
-
-
-setup_load_balancer() {
-    # resource that use a load balancer will be in pending state forever and 
-    # "helm install --wait" will never finish unless a loadbalancer is configured in the cluster
-
-    # https://kind.sigs.k8s.io/docs/user/loadbalancer/
-    docker_exec kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/master/manifests/namespace.yaml
-    docker_exec kubectl create secret generic -n metallb-system memberlist --from-literal=secretkey="$(openssl rand -base64 128)"
-    docker_exec kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/master/manifests/metallb.yaml
-    docker_exec kubectl apply -f https://kind.sigs.k8s.io/examples/loadbalancer/metallb-configmap.yaml
-}
-
 
 main() {
     run_ct_container


### PR DESCRIPTION
With https://github.com/datastax/pulsar-helm-chart/pull/162 merged, we no longer need the Metal LB solution.

Note that the current helm chart CI is failing because the download is unavailable:


>Setup metallb in k8s
error: unable to read URL "https://raw.githubusercontent.com/metallb/metallb/master/manifests/namespace.yaml", server reported 404 Not Found, status code=404
