### PR TITLE
Improve naming of TLS values for proxy, function worker, websocket proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,9 +566,9 @@ There are many components to consider when enabling TLS for a Pulsar Cluster. To
 endpoints, set `enableTls: true` in the values file and configure certificates. This setting will enable TLS endpoints
 for the Broker pods, Function Worker pods, and Proxy pods. However, this setting will not configure the proxy or the
 function worker to use TLS for connections with the broker. You can enable those by configuring
-`tls.proxy.enabled: true` and `tls.function.enabled: true`, respectively. Because the function worker only connects to
-the broker over TLS when authentication is configured, make sure to enable authentication if you'd like the function
-worker to connect to the broker over TLS.
+`tls.proxy.enableTlsWithBroker: true` and `tls.function.enableTlsWithBroker: true`, respectively. Because the function
+worker only connects to the broker over TLS when authentication is configured, make sure to enable authentication if
+you'd like the function worker to connect to the broker over TLS.
 
 #### Hostname Verification
 

--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -74,7 +74,7 @@ data:
     {{- end }}
     tlsKeyFilePath: "/pulsar/tls-pk8.key"
     {{- end }}
-    {{- if and .Values.enableTls .Values.tls.function.enabled }}
+    {{- if or (and .Values.enableTls .Values.tls.function.enabled) (and .Values.enableTls .Values.tls.function.enableTlsWithBroker) }}
     useTls: "true"
     tlsEnableHostnameVerification: "{{ .Values.tls.proxy.enableHostnameVerification }}"
     pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:6651"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -92,14 +92,14 @@ data:
   webServicePortTls: "8443"
   servicePortTls: "6651"
   # Used to enable via .Values.tls.function.enabled, but that is deprecated now.
-  {{- if or .Values.tls.function.enabled .Values.tls.proxy.enabled }}
+  {{- if or .Values.tls.function.enabled .Values.tls.proxy.enableTlsWithBroker }}
   tlsEnabledWithBroker: "true"
   tlsHostnameVerificationEnabled: "{{ .Values.tls.proxy.enableHostnameVerification }}"
   {{- else }}
   tlsEnabledWithBroker: "false"
   {{- end }}
   {{- if .Values.extra.function }}
-  {{- if or .Values.tls.function.enabled .Values.tls.proxy.enabled }}
+  {{- if or .Values.tls.function.enabled .Values.tls.proxy.enableTlsWithBroker }}
   functionWorkerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca:6751"
   {{- else }}
   functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca:6750"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -66,7 +66,8 @@ data:
   tlsEnabled: "true"
   tlsCertificateFilePath: /pulsar/certs/tls.crt
   tlsKeyFilePath: /pulsar/tls-pk8.key
-  {{- if or .Values.tls.websocket.enabled .Values.enableTls }}
+  # .Values.tls.websocket.enabled is deprecated
+  {{- if or (or .Values.tls.websocket.enabled .Values.enableTls) (and .Values.enableTls .Values.tls.websocket.enableTlsWithBroker) }}
   brokerClientTlsEnabled: "true"
   {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled}}
   tlsTrustCertsFilePath: /pulsar/certs/ca.crt

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -116,8 +116,9 @@ default_storage:
 # TLS-enabled ports on the service. To allow TLS connections only, remove the plain-text ports.
 # See the proxy and broker sections for details.
 # This flag enables TLS for all client and admin facing components: broker, proxy, websocket proxy, standalone function
-# worker. You must deploy the broker as a StatefulSet for hostname verification to work. The function worker and the
-# proxy will network with the brokers over TLS when this flag is set to true.
+# worker. You must deploy the broker as a StatefulSet for hostname verification to work. In order to enable Pulsar
+# components to network using TLS, see the tls.<component> section below; by default, intra cluster networking is
+# plaintext.
 enableTls: false
 tlsSecretName: pulsar-tls
 
@@ -150,15 +151,14 @@ tls:
   # NOTE: the function worker's connection to the broker is only over TLS if brokerClientAuthenticationEnabled is true
   # or if authenticationEnabled is true in the function's configuration.
   function:
-    enabled: false
+    enableTlsWithBroker: false
     # NOTE: temporarily false to allow for easy transition. In next major version bump, this will default to true.
     enableHostnameVerification: false
-  # Enable TLS between WebSocket proxy and broker
   websocket:
-    enabled: false
-  # Enable TLS between proxy and broker and between proxy and function worker
+    enableTlsWithBroker: false
   proxy:
-    enabled: false
+    # Applies to connections to standalone function worker, too.
+    enableTlsWithBroker: false
     # Applies to upstream broker and function worker TLS connections.
     # NOTE: temporarily false to allow for easy transition. In next major version bump, this will default to true.
     enableHostnameVerification: false


### PR DESCRIPTION
# Motivation

In #169, I attempted to improve the `enableTls` configuration. I realized shortly after merging that PR that the usage of `enabled` was problematic and a bit confusing. Instead, I am going to deprecate those usages in favor of a more descriptive value: `enableTlsWithBroker`.

This change is backwards compatible.