### PR TITLE
Pass Java Keystore password by file name; prevent keystore password from leaking in logs

### DIFF
--- a/examples/dev-values-zero-trust.yaml
+++ b/examples/dev-values-zero-trust.yaml
@@ -83,6 +83,7 @@ tls:
     createCertificates: true
     enableHostnameVerification: true
     tlsSecretName: "pulsar-zookeeper-tls"
+    configureKeystoreWithPasswordFile: true
   bookkeeper:
     enabled: true
     createCertificates: true

--- a/helm-chart-sources/pulsar/templates/utils/certconverter-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/certconverter-configmap.yaml
@@ -44,7 +44,7 @@ data:
     keyStoreFile=/pulsar/tls.keystore.jks
     trustStoreFile=/pulsar/tls.truststore.jks
 
-    PASSWORD=$(head /dev/urandom | base64 | head -c 24)
+    head /dev/urandom | base64 | head -c 24 > /pulsar/keystoreSecret.txt
 
     openssl pkcs12 \
         -export \
@@ -52,27 +52,33 @@ data:
         -inkey ${keyFile} \
         -out ${p12File} \
         -name ${name} \
-        -passout "pass:${PASSWORD}"
+        -passout "file:/pulsar/keystoreSecret.txt"
 
     keytool -importkeystore \
         -srckeystore ${p12File} \
-        -srcstoretype PKCS12 -srcstorepass "${PASSWORD}" \
+        -srcstoretype PKCS12 -srcstorepass:file "/pulsar/keystoreSecret.txt" \
         -alias ${name} \
         -destkeystore ${keyStoreFile} \
-        -deststorepass "${PASSWORD}"
+        -deststorepass:file "/pulsar/keystoreSecret.txt"
 
     keytool -import \
         -file ${caFile} \
         -storetype JKS \
         -alias ${name} \
         -keystore ${trustStoreFile} \
-        -storepass "${PASSWORD}" \
+        -storepass:file "/pulsar/keystoreSecret.txt" \
         -trustcacerts -noprompt
 
+    {{- if .Values.tls.zookeeper.configureKeystoreWithPasswordFile }}
+    passwordArg="passwordPath=/pulsar/keystoreSecret.txt"
+    {{- else }}
+    passwordArg="password=$(cat /pulsar/keystoreSecret.txt)"
+    {{- end }}
+
     echo $'\n' >> conf/pulsar_env.sh
-    echo "PULSAR_EXTRA_OPTS=\"${PULSAR_EXTRA_OPTS} -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=${keyStoreFile} -Dzookeeper.ssl.keyStore.password=${PASSWORD} -Dzookeeper.ssl.trustStore.location=${trustStoreFile} -Dzookeeper.ssl.trustStore.password=${PASSWORD} -Dzookeeper.sslQuorum=true -Dzookeeper.serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory -Dzookeeper.ssl.quorum.keyStore.location=${keyStoreFile} -Dzookeeper.ssl.quorum.keyStore.password=${PASSWORD} -Dzookeeper.ssl.quorum.trustStore.location=${trustStoreFile} -Dzookeeper.ssl.quorum.trustStore.password=${PASSWORD} -Dzookeeper.ssl.hostnameVerification={{ .Values.tls.zookeeper.enableHostnameVerification }} -Dzookeeper.ssl.quorum.hostnameVerification={{ .Values.tls.zookeeper.enableHostnameVerification }}\"" >> conf/pulsar_env.sh
+    echo "PULSAR_EXTRA_OPTS=\"${PULSAR_EXTRA_OPTS} -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=${keyStoreFile} -Dzookeeper.ssl.keyStore.${passwordArg} -Dzookeeper.ssl.trustStore.location=${trustStoreFile} -Dzookeeper.ssl.trustStore.${passwordArg} -Dzookeeper.sslQuorum=true -Dzookeeper.serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory -Dzookeeper.ssl.quorum.keyStore.location=${keyStoreFile} -Dzookeeper.ssl.quorum.keyStore.${passwordArg} -Dzookeeper.ssl.quorum.trustStore.location=${trustStoreFile} -Dzookeeper.ssl.quorum.trustStore.${passwordArg} -Dzookeeper.ssl.hostnameVerification={{ .Values.tls.zookeeper.enableHostnameVerification }} -Dzookeeper.ssl.quorum.hostnameVerification={{ .Values.tls.zookeeper.enableHostnameVerification }}\"" >> conf/pulsar_env.sh
 
     echo $'\n' >> conf/bkenv.sh
-    echo "BOOKIE_EXTRA_OPTS=\"${BOOKIE_EXTRA_OPTS} -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=${keyStoreFile} -Dzookeeper.ssl.keyStore.password=${PASSWORD} -Dzookeeper.ssl.trustStore.location=${trustStoreFile} -Dzookeeper.ssl.trustStore.password=${PASSWORD} -Dzookeeper.ssl.hostnameVerification={{ .Values.tls.zookeeper.enableHostnameVerification }}\"" >> conf/bkenv.sh
+    echo "BOOKIE_EXTRA_OPTS=\"${BOOKIE_EXTRA_OPTS} -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=${keyStoreFile} -Dzookeeper.ssl.keyStore.${passwordArg} -Dzookeeper.ssl.trustStore.location=${trustStoreFile} -Dzookeeper.ssl.trustStore.${passwordArg} -Dzookeeper.ssl.hostnameVerification={{ .Values.tls.zookeeper.enableHostnameVerification }}\"" >> conf/bkenv.sh
 
 {{- end }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -145,6 +145,8 @@ tls:
     enableHostnameVerification: false
     # If set, supersedes the root "tlsSecretName" config
     tlsSecretName: ""
+    # Starting in Zookeeper 3.8.0, it's possible to pass the Java Keystore password by file name.
+    configureKeystoreWithPasswordFile: false
   # Enable TLS between broker and BookKeeper, function worker and bookkeeper, and autorecovyer and bookkeeper
   bookkeeper:
     enabled: false


### PR DESCRIPTION
Fixes #164.

Instead of storing the password in an env var, now we write it to a file and pass it to zookeeper by file name. I used the previous mechanism to create a unique password in each pod and then write that password to a file. This solution is backwards compatible.

Alternatively, I could have made it possible to configure this password for each component. I think that would end up being more effort than it's worth, and it would have meant that the secret was the same for all pods in a group.