### PR TITLE
Fix tls-all example: use headless service

### DIFF
--- a/examples/dev-values-tls-all-components.yaml
+++ b/examples/dev-values-tls-all-components.yaml
@@ -158,6 +158,8 @@ bookkeeper:
 brokerSts:
   component: broker
   replicaCount: 1
+  service:
+    headless: true
   ledger:
     defaultEnsembleSize: 1
     defaultAckQuorum: 1


### PR DESCRIPTION
## Motivation

In testing, @yabinmeng observed that the newly created `examples/dev-values-tls-all-components.yaml` file was not working on GCP because the function worker failed with the following error:

> 03:37:06.934 [pulsar-client-io-22-1] WARN  org.apache.pulsar.client.impl.ConnectionPool - Failed to open connection to pulsar-broker-0.pulsar-broker.pulsar.svc.cluster.local:6651 : io.netty.resolver.dns.DnsResolveContext$Searc
hDomainUnknownHostException: Failed to resolve 'pulsar-broker-0.pulsar-broker.pulsar.svc.cluster.local' and search domain query for configured domains failed as well: [pulsar.svc.cluster.local, svc.cluster.local, cluster.local
, c.datastax-astrastreaming-stage.internal, google.internal]

In looking closer, the underlying issue was a misconfiguration in the `brokerSts`. It must be a headless service in order for the StatefulSet stable network identifies to work (see https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations)

> StatefulSets currently require a [Headless Service](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services) to be responsible for the network identity of the Pods. You are responsible for creating this Service.

The fundamental issue was that the broker's individual DNS name did not resolve correctly.

## Background

I did not observe this issue during testing because minikube apparently does not have the documented kubernetes limitation.