### PR TITLE
[CI] Run install-charts with multiple k8s versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ jobs:
           command: ct lint --config tests/ct.yaml
 
   install-charts:
+    parameters:
+      k8s-version:
+        type: string
     machine:
       image: ubuntu-2004:202107-02
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: tests/e2e-kind.sh
+          command: K8S_VERSION=<< parameters.k8s-version >> tests/e2e-kind.sh
           no_output_timeout: 1h
 
   release-charts:
@@ -51,6 +51,9 @@ workflows:
           requires:
             - lint-scripts
             - lint-charts
+          matrix:
+            parameters:
+              k8s-version: ["v1.18.20", "v1.21.10", "v1.23.5"]
   release:
     jobs:
       - release-charts:

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 readonly CT_VERSION=latest
 readonly KIND_VERSION=v0.11.1
-readonly K8S_VERSION=v1.21.2
+readonly : "${K8S_VERSION:=v1.21.2}"
 
 readonly CLUSTER_NAME=pulsar-helm-test
 

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 readonly CT_VERSION=latest
 readonly KIND_VERSION=v0.11.1
-readonly : "${K8S_VERSION:=v1.21.2}"
+: "${K8S_VERSION:=v1.21.2}"
 
 readonly CLUSTER_NAME=pulsar-helm-test
 


### PR DESCRIPTION
Add workflows to deploy helmchart on different k8s versions:
1. 1.18.20
2. 1.21.10
3. 1.23.5

Resolves #177 .