### PR TITLE
Configure TLS using a KeyStore

### DIFF
--- a/examples/dev-values-tls-all-components.yaml
+++ b/examples/dev-values-tls-all-components.yaml
@@ -20,27 +20,27 @@ image:
     # If not using tiered storage, you can use the smaller pulsar image for the broker
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.4
+    tag: 2.8.3_1.0.7
   function:
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.4
+    tag: 2.8.3_1.0.7
   zookeeper:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.4
+    tag: 2.8.3_1.0.7
   bookkeeper:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.4
+    tag: 2.8.3_1.0.7
   proxy:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.4
+    tag: 2.8.3_1.0.7
   bastion:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.4
+    tag: 2.8.3_1.0.7
   pulsarBeam:
     repository: kesque/pulsar-beam
     pullPolicy: IfNotPresent
@@ -55,7 +55,7 @@ image:
     tag: logcollector_latest
   pulsarSQL:
     repository: datastax/lunastreaming-all
-    tag: 2.8.3_1.0.4
+    tag: 2.8.3_1.0.7
     pullPolicy: IfNotPresent
   tardigrade:
     repository: storjlabs/gateway

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
@@ -151,12 +151,10 @@ spec:
         - name: certs
           secret:
             secretName: "{{ .Values.tlsSecretName }}"
-          {{- if .Values.tls.zookeeper.enabled}}
         - name: certconverter
           configMap:
             name: "{{ template "pulsar.fullname" . }}-certconverter-configmap"
             defaultMode: 0755
-          {{- end }}
         {{- end }}
         {{- if .Values.enableTokenAuth }}
         - name: token-public-key
@@ -234,17 +232,15 @@ spec:
         command: ["sh", "-c"]
         args:
         - >
+          {{- if .Values.enableTls }}
+          openssl pkcs8 -topk8 -inform PEM -outform PEM -in /pulsar/certs/tls.key -out /pulsar/tls-pk8.key -nocrypt &&
+          . /pulsar/tools/certconverter.sh &&
+          {{- end }}
           bin/apply-config-from-env.py conf/broker.conf &&
           bin/apply-config-from-env.py conf/client.conf &&
           bin/gen-yml-from-env.py conf/functions_worker.yml &&
-          {{- if .Values.enableTls }}
-          openssl pkcs8 -topk8 -inform PEM -outform PEM -in /pulsar/certs/tls.key -out /pulsar/tls-pk8.key -nocrypt &&
-          {{- end }}
           {{- if .Values.enableTokenAuth }}
           cat /pulsar/token-superuser/superuser.jwt | tr -d '\n' > /pulsar/token-superuser-stripped.jwt &&
-          {{- end }}
-          {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
-          /pulsar/tools/certconverter.sh &&
           {{- end }}
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar broker
         ports:
@@ -259,10 +255,8 @@ spec:
           - name: certs
             readOnly: true
             mountPath: /pulsar/certs
-            {{- if .Values.tls.zookeeper.enabled}}
           - name: certconverter
             mountPath: /pulsar/tools
-            {{- end }}
           {{- end }}
           {{- if .Values.broker.initContainer }}
           - name: lib-data

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -106,6 +106,9 @@ data:
   brokerServicePortTls: "6651"
   brokerClientTlsEnabled: "true"
   webServicePortTls: "8443"
+  tlsEnabledWithKeyStore: "true"
+  tlsKeyStore: "/pulsar/tls.keystore.jks"
+  tlsTrustStore: "/pulsar/tls.truststore.jks"
   {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled .Values.createCertificates.selfSignedPerComponent.enabled }}
   brokerClientTrustCertsFilePath: /pulsar/certs/ca.crt
   {{- else }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
@@ -148,12 +148,10 @@ spec:
         - name: certs
           secret:
             secretName: {{ .Values.tls.broker.tlsSecretName | default .Values.tlsSecretName | quote }}
-          {{- if .Values.tls.zookeeper.enabled}}
         - name: certconverter
           configMap:
             name: "{{ template "pulsar.fullname" . }}-certconverter-configmap"
             defaultMode: 0755
-          {{- end }}
         {{- end }}
         {{- if .Values.enableTokenAuth }}
         - name: token-public-key
@@ -231,17 +229,15 @@ spec:
         command: ["sh", "-c"]
         args:
         - >
+          {{- if .Values.enableTls }}
+          openssl pkcs8 -topk8 -inform PEM -outform PEM -in /pulsar/certs/tls.key -out /pulsar/tls-pk8.key -nocrypt &&
+          . /pulsar/tools/certconverter.sh &&
+          {{- end }}
           bin/apply-config-from-env.py conf/broker.conf &&
           bin/apply-config-from-env.py conf/client.conf &&
           bin/gen-yml-from-env.py conf/functions_worker.yml &&
-          {{- if .Values.enableTls }}
-          openssl pkcs8 -topk8 -inform PEM -outform PEM -in /pulsar/certs/tls.key -out /pulsar/tls-pk8.key -nocrypt &&
-          {{- end }}
           {{- if .Values.enableTokenAuth }}
           cat /pulsar/token-superuser/superuser.jwt | tr -d '\n' > /pulsar/token-superuser-stripped.jwt &&
-          {{- end }}
-          {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
-          /pulsar/tools/certconverter.sh &&
           {{- end }}
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar broker
         ports:
@@ -256,10 +252,8 @@ spec:
           - name: certs
             readOnly: true
             mountPath: /pulsar/certs
-            {{- if .Values.tls.zookeeper.enabled}}
           - name: certconverter
             mountPath: /pulsar/tools
-            {{- end }}
           {{- end }}
           {{- if .Values.brokerSts.initContainer }}
           - name: lib-data

--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -79,6 +79,9 @@ data:
     {{- end }}
     {{- if or (and .Values.enableTls .Values.tls.function.enabled) (and .Values.enableTls .Values.tls.function.enableTlsWithBroker) }}
     useTls: "true"
+    tlsEnabledWithKeyStore: "true"
+    tlsKeyStore: "/pulsar/tls.keystore.jks"
+    tlsTrustStore: "/pulsar/tls.truststore.jks"
     tlsEnableHostnameVerification: "{{ .Values.tls.function.enableHostnameVerification }}"
     pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:6651"
     pulsarWebServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443"

--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -143,12 +143,10 @@ spec:
         - name: certs
           secret:
             secretName: {{ .Values.tls.function.tlsSecretName | default .Values.tlsSecretName | quote }}
-         {{- if .Values.tls.zookeeper.enabled}}
         - name: certconverter
           configMap:
             name: "{{ template "pulsar.fullname" . }}-certconverter-configmap"
             defaultMode: 0755
-          {{- end }}
         {{- end }}
       {{- if not .Values.persistence }}
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-{{ .Values.function.volumes.data.name }}"
@@ -209,18 +207,16 @@ spec:
           {{- if .Values.function.initContainer.mainContainerStartupCmd }}
           {{ .Values.function.initContainer.mainContainerStartupCmd }} &&
           {{- end }}
+          {{- if .Values.enableTls }}
+          openssl pkcs8 -topk8 -inform PEM -outform PEM -in /pulsar/certs/tls.key -out /pulsar/tls-pk8.key -nocrypt &&
+          . /pulsar/tools/certconverter.sh &&
+          {{- end }}
           bin/apply-config-from-env.py conf/broker.conf &&
           cp -f funcconf/functions_worker.yml conf/functions_worker.yml &&
           export PF_workerHostname="${workerHostname}.{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}" &&
           bin/gen-yml-from-env.py conf/functions_worker.yml &&
-          {{- if .Values.enableTls }}
-          openssl pkcs8 -topk8 -inform PEM -outform PEM -in /pulsar/certs/tls.key -out /pulsar/tls-pk8.key -nocrypt &&
-          {{- end }}
           {{- if .Values.function.usePython3 }}
           /pulsar/bin/set_python_version.sh &&
-          {{- end }}
-          {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
-          /pulsar/tools/certconverter.sh &&
           {{- end }}
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar functions-worker
         ports:
@@ -259,10 +255,8 @@ spec:
           - name: certs
             readOnly: true
             mountPath: /pulsar/certs
-            {{- if .Values.tls.zookeeper.enabled}}
           - name: certconverter
             mountPath: /pulsar/tools
-            {{- end }}
           {{- end }}
           - name: config-volume
             mountPath: /pulsar/funcconf/functions_worker.yml

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -74,6 +74,10 @@ data:
   functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca:6750"
   {{- end }}
 {{- if .Values.enableTls }}
+  tlsEnabledWithKeyStore: "true"
+  tlsKeyStore: "/pulsar/tls.keystore.jks"
+  tlsTrustStore: "/pulsar/tls.truststore.jks"
+  PULSAR_PREFIX_brokerClientTlsTrustStore: "/pulsar/tls.truststore.jks"
   tlsEnabledInProxy: "true"
   tlsEnableHostnameVerification: "true"
   tlsCertificateFilePath: /pulsar/certs/tls.crt

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -151,12 +151,10 @@ spec:
         - name: certs
           secret:
             secretName: {{ .Values.tls.proxy.tlsSecretName | default .Values.tlsSecretName | quote }}
-         {{- if .Values.tls.zookeeper.enabled}}
         - name: certconverter
           configMap:
             name: "{{ template "pulsar.fullname" . }}-certconverter-configmap"
             defaultMode: 0755
-          {{- end }}
         {{- end }}
         {{- if .Values.enableTokenAuth }}
         - name: token-public-key
@@ -251,13 +249,11 @@ spec:
           {{- if .Values.enableTokenAuth }}
           cat /pulsar/token-superuser/superuser.jwt | tr -d '\n' > /pulsar/token-superuser-stripped.jwt &&
           {{- end }}
-          bin/apply-config-from-env.py conf/proxy.conf &&
           {{- if .Values.enableTls }}
           openssl pkcs8 -topk8 -inform PEM -outform PEM -in /pulsar/certs/tls.key -out /pulsar/tls-pk8.key -nocrypt &&
+          . /pulsar/tools/certconverter.sh &&
           {{- end }}
-          {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
-          /pulsar/tools/certconverter.sh &&
-          {{- end }}
+          bin/apply-config-from-env.py conf/proxy.conf &&
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar proxy
         ports:
         - name: wss
@@ -272,10 +268,8 @@ spec:
           - name: certs
             readOnly: true
             mountPath: /pulsar/certs
-            {{- if .Values.tls.zookeeper.enabled}}
           - name: certconverter
             mountPath: /pulsar/tools
-            {{- end }}
           {{- end }}
           {{- if .Values.enableTokenAuth }}
           - mountPath: "/pulsar/token-public-key"
@@ -309,13 +303,11 @@ spec:
           {{- if .Values.enableTokenAuth }}
           echo "tokenPublicKey=" >> /pulsar/conf/websocket.conf &&
           {{- end }}
-          bin/apply-config-from-env.py conf/websocket.conf &&
           {{- if .Values.enableTls }}
           openssl pkcs8 -topk8 -inform PEM -outform PEM -in /pulsar/certs/tls.key -out /pulsar/tls-pk8.key -nocrypt &&
+          . /pulsar/tools/certconverter.sh &&
           {{- end }}
-          {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
-          /pulsar/tools/certconverter.sh &&
-          {{- end }}
+          bin/apply-config-from-env.py conf/websocket.conf &&
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar websocket
         ports:
         - name: http
@@ -327,10 +319,8 @@ spec:
           - name: certs
             readOnly: true
             mountPath: /pulsar/certs
-            {{- if .Values.tls.zookeeper.enabled}}
           - name: certconverter
             mountPath: /pulsar/tools
-            {{- end }}
           {{- end }}
           {{- if .Values.enableTokenAuth }}
           - mountPath: "/pulsar/token-public-key"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -66,6 +66,9 @@ data:
   tlsEnabled: "true"
   tlsCertificateFilePath: /pulsar/certs/tls.crt
   tlsKeyFilePath: /pulsar/tls-pk8.key
+  tlsEnabledWithKeyStore: "true"
+  tlsKeyStore: "/pulsar/tls.keystore.jks"
+  tlsTrustStore: "/pulsar/tls.truststore.jks"
   # .Values.tls.websocket.enabled is deprecated
   {{- if or (or .Values.tls.websocket.enabled .Values.enableTls) (and .Values.enableTls .Values.tls.websocket.enableTlsWithBroker) }}
   brokerClientTlsEnabled: "true"

--- a/helm-chart-sources/pulsar/templates/utils/certconverter-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/certconverter-configmap.yaml
@@ -15,7 +15,7 @@
 #
 #
 
-{{- if .Values.tls.zookeeper.enabled }}
+{{- if .Values.enableTls }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -45,6 +45,11 @@ data:
     trustStoreFile=/pulsar/tls.truststore.jks
 
     head /dev/urandom | base64 | head -c 24 > /pulsar/keystoreSecret.txt
+    export tlsTrustStorePassword=$(cat /pulsar/keystoreSecret.txt)
+    export PF_tlsTrustStorePassword=$(cat /pulsar/keystoreSecret.txt)
+    export tlsKeyStorePassword=$(cat /pulsar/keystoreSecret.txt)
+    export PF_tlsKeyStorePassword=$(cat /pulsar/keystoreSecret.txt)
+    export PULSAR_PREFIX_brokerClientTlsTrustStorePassword=$(cat /pulsar/keystoreSecret.txt)
 
     openssl pkcs12 \
         -export \
@@ -69,6 +74,7 @@ data:
         -storepass:file "/pulsar/keystoreSecret.txt" \
         -trustcacerts -noprompt
 
+    {{- if .Values.tls.zookeeper.enabled }}
     {{- if .Values.tls.zookeeper.configureKeystoreWithPasswordFile }}
     passwordArg="passwordPath=/pulsar/keystoreSecret.txt"
     {{- else }}
@@ -80,5 +86,6 @@ data:
 
     echo $'\n' >> conf/bkenv.sh
     echo "BOOKIE_EXTRA_OPTS=\"${BOOKIE_EXTRA_OPTS} -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=${keyStoreFile} -Dzookeeper.ssl.keyStore.${passwordArg} -Dzookeeper.ssl.trustStore.location=${trustStoreFile} -Dzookeeper.ssl.trustStore.${passwordArg} -Dzookeeper.ssl.hostnameVerification={{ .Values.tls.zookeeper.enableHostnameVerification }}\"" >> conf/bkenv.sh
+    {{- end }}
 
 {{- end }}


### PR DESCRIPTION
# Motivation

By using a KeyStore to configure TLS for Pulsar components, we're able to support additional algorithms, like ECDSA.

# Changes

* Use the `certconverter-configmap` to generate the keystore (right now it is JKS, but it should be PKCS12 in a future iteration)
* Set password environment variables
* Set the relevant TLS configurations