### PR TITLE
Enable Private Key Algorithm Configuration for Cert Manager

### DIFF
--- a/examples/dev-values-tls-all-components.yaml
+++ b/examples/dev-values-tls-all-components.yaml
@@ -84,35 +84,72 @@ tls:
     enableHostnameVerification: true
     tlsSecretName: "pulsar-zookeeper-tls"
     configureKeystoreWithPasswordFile: true
+    certSpec:
+      privateKey:
+        algorithm: "ECDSA"
+        size: 256
   bookkeeper:
     enabled: true
     createCertificates: true
     tlsSecretName: "pulsar-bookkeeper-tls"
+    certSpec:
+      privateKey:
+        algorithm: "ECDSA"
+        size: 256
   function:
     enableTlsWithBroker: true
     createCertificates: true
     tlsSecretName: "pulsar-function-tls"
     enableHostnameVerification: true
+    certSpec:
+      privateKey:
+        algorithm: "ECDSA"
+        size: 256
   websocket:
     enableTlsWithBroker: true
     enableHostnameVerification: true
+    certSpec:
+      privateKey:
+        algorithm: "ECDSA"
+        size: 256
   proxy:
     enableTlsWithBroker: true
     enableHostnameVerification: true
     createCertificates: true
     tlsSecretName: "pulsar-proxy-tls"
+    certSpec:
+      privateKey:
+        algorithm: "ECDSA"
+        size: 256
   broker:
     createCertificates: true
     tlsSecretName: "pulsar-broker-tls"
+    certSpec:
+      privateKey:
+        algorithm: "ECDSA"
+        size: 256
   # Certificate used for TLS authentication with bookkeeper and zookeeper
   autoRecovery:
     enableHostnameVerification: true
     createCertificates: true
     tlsSecretName: "pulsar-autorecovery-tls"
+    certSpec:
+      privateKey:
+        algorithm: "ECDSA"
+        size: 256
   pulsarAdminConsole:
     enableTlsWithBroker: true
     createCertificates: true
     tlsSecretName: "pulsar-adminconsole-tls"
+    certSpec:
+      privateKey:
+        algorithm: "ECDSA"
+        size: 256
+  ssCaCert:
+    certSpec:
+      privateKey:
+        algorithm: "ECDSA"
+        size: 256
   rootCaSecretName: "pulsar-ss-ca"
 
 # The current function worker code only uses TLS connections to brokers when authentication is enabled, so enable it here.

--- a/helm-chart-sources/pulsar/templates/cert-manager/self-signed-cert-per-component.yaml
+++ b/helm-chart-sources/pulsar/templates/cert-manager/self-signed-cert-per-component.yaml
@@ -32,6 +32,10 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-ca-certificate"
   namespace: "{{ .Release.Namespace }}"
 spec:
+  {{- if .Values.tls.ssCaCert.certSpec.privateKey }}
+  privateKey:
+{{ toYaml .Values.tls.ssCaCert.certSpec.privateKey | indent 4 }}
+  {{- end }}
   secretName: "{{ template "pulsar.fullname" . }}-ss-ca"
   commonName: "{{ .Release.Namespace }}.svc.cluster.local"
   usages:
@@ -58,6 +62,10 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}-tls"
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.tls.broker.certSpec.privateKey }}
+  privateKey:
+{{ toYaml .Values.tls.broker.certSpec.privateKey | indent 4 }}
+  {{- end }}
   secretName: {{ required "Must set .Values.tls.broker.tlsSecretName to create certificates for broker" .Values.tls.broker.tlsSecretName }}
   # The wildcard names are needed to connect directly to the broker.
   # The non-wildcard broker names are needed when calling the topic lookup service.
@@ -80,6 +88,10 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-tls"
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.tls.bookkeeper.certSpec.privateKey }}
+  privateKey:
+{{ toYaml .Values.tls.bookkeeper.certSpec.privateKey | indent 4 }}
+  {{- end }}
   secretName: {{ .Values.tls.bookkeeper.tlsSecretName }}
   # The wildcard names are needed to connect directly to the broker.
   dnsNames:
@@ -101,6 +113,10 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-tls"
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.tls.proxy.certSpec.privateKey }}
+  privateKey:
+{{ toYaml .Values.tls.proxy.certSpec.privateKey | indent 4 }}
+  {{- end }}
   secretName: {{ required "Must set .Values.tls.proxy.tlsSecretName to create certificates for proxy" .Values.tls.proxy.tlsSecretName }}
   dnsNames:
     - "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local"
@@ -118,6 +134,10 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-tls"
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.tls.zookeeper.certSpec.privateKey }}
+  privateKey:
+{{ toYaml .Values.tls.zookeeper.certSpec.privateKey | indent 4 }}
+  {{- end }}
   secretName: {{ required "Must set .Values.tls.zookeeper.tlsSecretName to create certificates for zookeeper" .Values.tls.zookeeper.tlsSecretName }}
   # The DNS names ending in "-ca" are meant for client access. The wildcard names are used for zookeeper to zookeeper
   # networking.
@@ -143,6 +163,10 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-tls"
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.tls.function.certSpec.privateKey }}
+  privateKey:
+{{ toYaml .Values.tls.function.certSpec.privateKey | indent 4 }}
+  {{- end }}
   secretName: {{ required "Must set .Values.tls.function.tlsSecretName to create certificates for function worker" .Values.tls.function.tlsSecretName }}
   # The DNS names ending in "-ca" are meant for client access. The wildcard names are used for zookeeper to zookeeper
   # networking.
@@ -168,6 +192,10 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autoRecovery.component }}-tls"
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.tls.autoRecovery.certSpec.privateKey }}
+  privateKey:
+{{ toYaml .Values.tls.autoRecovery.certSpec.privateKey | indent 4 }}
+  {{- end }}
   # TODO This cert is only used for TLS authentication. Figure out what is needed for the name, if anything.
   commonName: autorecovery
   usages:
@@ -185,6 +213,10 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}-tls"
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.tls.pulsarAdminConsole.certSpec.privateKey }}
+  privateKey:
+{{ toYaml .Values.tls.pulsarAdminConsole.certSpec.privateKey | indent 4 }}
+  {{- end }}
   secretName: {{ required "Must set .Values.tls.pulsarAdminConsole.tlsSecretName to create certificates for pulsarAdminConsole" .Values.tls.pulsarAdminConsole.tlsSecretName }}
   dnsNames:
     - "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}.{{ .Release.Namespace }}.svc.cluster.local"

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -147,12 +147,20 @@ tls:
     tlsSecretName: ""
     # Starting in Zookeeper 3.8.0, it's possible to pass the Java Keystore password by file name.
     configureKeystoreWithPasswordFile: false
+    certSpec:
+      # Spec defined here: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
+      # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
+      privateKey: {}
   # Enable TLS between broker and BookKeeper, function worker and bookkeeper, and autorecovyer and bookkeeper
   bookkeeper:
     enabled: false
     createCertificates: false
     # If set, supersedes the root "tlsSecretName" config
     tlsSecretName: ""
+    certSpec:
+      # Spec defined here: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
+      # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
+      privateKey: {}
 
   ## TLS is enabled for the function worker, broker, and proxy when enableTls is true. The below <component>.enableTlsWithBroker
   ## flags are used to determine whether the component's client should use TLS when connecting to the broker or the
@@ -169,6 +177,10 @@ tls:
     createCertificates: false
     # If set, supersedes the root "tlsSecretName" config
     tlsSecretName: ""
+    certSpec:
+      # Spec defined here: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
+      # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
+      privateKey: {}
   # Websocket will use the tls.proxy.tlsSecretName for TLS
   websocket:
     enableTlsWithBroker: false
@@ -181,6 +193,10 @@ tls:
     createCertificates: false
     # If set, supersedes the root "tlsSecretName" config
     tlsSecretName: ""
+    certSpec:
+      # Spec defined here: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
+      # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
+      privateKey: {}
 
   broker:
     enableForProxyToBroker: false
@@ -188,6 +204,10 @@ tls:
     createCertificates: false
     # If set, supersedes the root "tlsSecretName" config
     tlsSecretName: ""
+    certSpec:
+      # Spec defined here: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
+      # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
+      privateKey: {}
 
   # Certificate used for TLS client authentication with bookkeeper and zookeeper, and for verifying self-signed certs
   autoRecovery:
@@ -196,6 +216,10 @@ tls:
     enableHostnameVerification: false
     # If set, supersedes the root "tlsSecretName" config
     tlsSecretName: ""
+    certSpec:
+      # Spec defined here: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
+      # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
+      privateKey: {}
 
   pulsarAdminConsole:
     # Applies to all upstream targets
@@ -203,6 +227,17 @@ tls:
     createCertificates: false
     # If set, supersedes the root "tlsSecretName" config
     tlsSecretName: ""
+    certSpec:
+      # Spec defined here: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
+      # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
+      privateKey: {}
+
+  # Configuration for the CA Certificate. Only applied when using Cert Manager's self-signed certs per component.
+  ssCaCert:
+    certSpec:
+      # Spec defined here: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
+      # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
+      privateKey: {}
 
   # If using self-signed certs, it's essential to mount the root CA for TLS verification. If this value is specified,
   # the chart will mount this secret's item named ca.crt to /pulsar/certs/ca.crt.


### PR DESCRIPTION
## Motivation

In a recent release, we added support for TLS using ECDSA algorithms. This PR makes it possible to configure the algorithm that Cert Manager uses to create Certificates.

## Changes

* Update the dev-values-tls-all-components.yaml example to utilize this new feature.
* Add a configuration option to configure the self signed certs per component using https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey

This change is completely backwards compatible.