### PR TITLE
Make Pulsar Heartbeat use TLS when enabled

### DIFF
--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-configmap.yaml
@@ -25,7 +25,7 @@ data:
     name: {{ template "pulsar.fullname" . }}
     token: {{ .Values.pulsarHeartbeat.config.pulsarClientToken }}
     tokenFilePath: {{ .Values.pulsarHeartbeat.config.tokenFilePath }}
-    trustStore: {{ .Values.pulsarHeartbeat.config.trustStore }}
+    trustStore: {{ .Values.pulsarHeartbeat.config.trustStore | default "/pulsar/certs/ca.crt" }}
     analyticsConfig:
       apiKey: {{ .Values.pulsarHeartbeat.config.analyticsApiKey }}
       ingestionURL: {{ .Values.pulsarHeartbeat.config.analyticsUrl }}
@@ -54,7 +54,11 @@ data:
     brokersConfig:
       {{- if .Values.pulsarHeartbeat.config.broker }}
       intervalSeconds: {{ .Values.pulsarHeartbeat.config.broker.intervalSeconds | default 45 }}
+      {{- if .Values.enableTls }}
+      inclusterRestURL: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443"
+      {{- else }}
       inclusterRestURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080"
+      {{- end }}
       alertPolicy:
         Ceiling: {{ .Values.pulsarHeartbeat.config.broker.alertCeiling | default 5 }}
         MovingWindowSeconds: {{ .Values.pulsarHeartbeat.config.broker.alertWindowSeconds | default 600 }}
@@ -65,7 +69,11 @@ data:
       intervalSeconds: {{ .Values.pulsarHeartbeat.config.adminRest.intervalSeconds | default 120 }}
       clusters:
         - name: {{ template "pulsar.fullname" . }}
+          {{- if .Values.enableTls }}
+          url: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443"
+          {{- else }}
           url: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080"
+          {{- end }}
           alertPolicy:
             Ceiling: {{ .Values.pulsarHeartbeat.config.adminRest.alertCeiling | default 5 }}
             MovingWindowSeconds: 600
@@ -76,7 +84,11 @@ data:
       - latencyBudgetMs: {{ .Values.pulsarHeartbeat.config.latencyTest.budgetMs | default 60 }}
         name: "pubsub-latency-incluster-{{ template "pulsar.fullname" . }}"
         intervalSeconds: {{ .Values.pulsarHeartbeat.config.latencyTest.intervalSeconds | default 60 }}
+        {{- if .Values.enableTls }}
+        pulsarUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:6651"
+        {{- else }}
         pulsarUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650"
+        {{- end }}
         topicName: {{ .Values.pulsarHeartbeat.config.latencyTest.intervalSeconds | default "persistent://public/default/pubsub-latency-test" }}
         payloadSizes: [15B]
         numberOfMessages: 1

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
@@ -59,6 +59,14 @@ spec:
         - name: config-volume
           configMap:
             name: "{{ include "pulsar.fullname" . }}-{{ .Values.pulsarHeartbeat.component }}-config"
+        {{- if .Values.enableTls }}
+        - name: certs
+          secret:
+            secretName: {{ .Values.tls.rootCaSecretName | default .Values.tlsSecretName | quote }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+        {{- end }}
       initContainers:
       {{- if .Values.pulsarHeartbeat.enableWaitContainers | default true }}
       # This init container will wait for bookkeeper to be ready before
@@ -95,13 +103,22 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /config
+          {{- if .Values.enableTls }}
+          - name: certs
+            readOnly: true
+            mountPath: /pulsar/certs
+          {{- end }}
           env:
           - name: DeployEnv
             value: production
           - name: ClusterName
             value: "{{ template "pulsar.fullname" . }}"
           - name: BrokerProxyURL
+            {{- if .Values.enableTls }}
+            value: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443"
+            {{- else }}
             value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080"
+            {{- end }}
           {{- if .Values.enableTokenAuth }}
           - name: PulsarToken
             valueFrom:
@@ -110,7 +127,11 @@ spec:
                 key: superuser.jwt
           {{- end }}
           - name: PulsarURL
+            {{- if .Values.enableTls }}
+            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:6651"
+            {{- else }}
             value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650"
+            {{- end }}
       {{- with .Values.pulsarHeartbeat.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1688,6 +1688,8 @@ pulsarHeartbeat:
   config:
     k8sInClusterMonitorEnabled: "false"
     alertUrl:
+    # If not supplied, defaults to "/pulsar/certs/ca.crt"
+    trustStore:
     opsGenieHeartbeatUrl:
     opsGenieHeartbeatKey:
     opsGenieAlertKey:


### PR DESCRIPTION
The Pulsar Heartbeat project supports TLS connections to Pulsar. When we `enableTls` is true in the value file, we should utilize `pulsar+ssl` and `https` to network with the broker.