### PR TITLE
Use FQDN for service names

### DIFF
--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-configmap.yaml
@@ -84,9 +84,9 @@ data:
         "oauth_client_id": "{{ .Values.pulsarAdminConsole.oauthClientId }}",
         "host_overrides": {
             {{- if .Values.pulsarAdminConsole.codeSampleUrl.useDnsName }}
-            "pulsar": "pulsar+ssl://{{ .Values.dnsName }}:6651",
-            "ws": "wss://{{ .Values.dnsName }}:8001",
-            "http": "https://{{ .Values.dnsName }}:8085"
+            "pulsar": "pulsar+ssl://{{ .Values.dnsName }}.{{ .Release.Namespace }}.svc.cluster.local:6651",
+            "ws": "wss://{{ .Values.dnsName }}.{{ .Release.Namespace }}.svc.cluster.local:8001",
+            "http": "https://{{ .Values.dnsName }}.{{ .Release.Namespace }}.svc.cluster.local:8085"
             {{- else }}
             "pulsar": "{{ .Values.pulsarAdminConsole.codeSampleUrl.pulsar }}",
             "ws": "{{ .Values.pulsarAdminConsole.codeSampleUrl.websocket }}",

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-configmap.yaml
@@ -84,9 +84,9 @@ data:
         "oauth_client_id": "{{ .Values.pulsarAdminConsole.oauthClientId }}",
         "host_overrides": {
             {{- if .Values.pulsarAdminConsole.codeSampleUrl.useDnsName }}
-            "pulsar": "pulsar+ssl://{{ .Values.dnsName }}.{{ .Release.Namespace }}.svc.cluster.local:6651",
-            "ws": "wss://{{ .Values.dnsName }}.{{ .Release.Namespace }}.svc.cluster.local:8001",
-            "http": "https://{{ .Values.dnsName }}.{{ .Release.Namespace }}.svc.cluster.local:8085"
+            "pulsar": "pulsar+ssl://{{ .Values.dnsName }}:6651",
+            "ws": "wss://{{ .Values.dnsName }}:8001",
+            "http": "https://{{ .Values.dnsName }}:8085"
             {{- else }}
             "pulsar": "{{ .Values.pulsarAdminConsole.codeSampleUrl.pulsar }}",
             "ws": "{{ .Values.pulsarAdminConsole.codeSampleUrl.websocket }}",

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -63,21 +63,21 @@ data:
 
       upstream http-pulsar-proxy {
       {{- if .Values.enableTls }}
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443;
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443;
       {{- else }}
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080;
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080;
       {{- end }}
       }
 
       upstream pulsar-burnell {
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8964;
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8964;
       }
 
       upstream ws-pulsar-proxy {
       {{- if .Values.enableTls }}
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8001;
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8001;
       {{- else }}
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8000;
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8000;
       {{- end }}
       }
 

--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-nginx-configmap.yaml
@@ -63,21 +63,21 @@ data:
 
       upstream http-pulsar-proxy {
       {{- if .Values.enableTls }}
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8443;
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443;
       {{- else }}
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8080;
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080;
       {{- end }}
       }
 
       upstream pulsar-burnell {
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8964;
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8964;
       }
 
       upstream ws-pulsar-proxy {
       {{- if .Values.enableTls }}
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8001;
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8001;
       {{- else }}
-        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8000;
+        server {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8000;
       {{- end }}
       }
 

--- a/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-configmap.yaml
@@ -32,15 +32,15 @@ data:
   zkServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
       {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
       {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
       {{- end }}
     {{- else }}
       {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
       {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
       {{- end }}
     {{- end }}
   {{- if and .Values.enableTls .Values.tls.bookkeeper.enabled }}

--- a/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-configmap.yaml
@@ -32,15 +32,15 @@ data:
   zkServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
       {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
       {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
       {{- end }}
     {{- else }}
       {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
       {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
       {{- end }}
     {{- end }}
   {{- if and .Values.enableTls .Values.tls.bookkeeper.enabled }}

--- a/helm-chart-sources/pulsar/templates/bastion/bastion-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion/bastion-configmap.yaml
@@ -43,19 +43,19 @@ data:
   tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
     {{- end }}
     {{- if .Values.extra.proxy }}
-  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651/"
-  webServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443/"
+  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651/"
+  webServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443/"
     {{- else }}
-  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651/"
-  webServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443/"
+  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651/"
+  webServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443/"
     {{- end }}
   {{- else }}
     {{- if .Values.extra.proxy }}
-  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/"
-  webServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080/"
+  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650/"
+  webServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080/"
     {{- else }}
-  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/"
-  webServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080/"
+  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650/"
+  webServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080/"
     {{- end }}
   {{- end }}
 {{- range $key, $val := $.Values.bastion.configData }}

--- a/helm-chart-sources/pulsar/templates/bastion/bastion-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion/bastion-configmap.yaml
@@ -43,19 +43,19 @@ data:
   tlsTrustCertsFilePath: "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}"
     {{- end }}
     {{- if .Values.extra.proxy }}
-  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:6651/"
-  webServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8443/"
+  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651/"
+  webServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443/"
     {{- else }}
-  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:6651/"
-  webServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443/"
+  brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651/"
+  webServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443/"
     {{- end }}
   {{- else }}
     {{- if .Values.extra.proxy }}
-  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:6650/"
-  webServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8080/"
+  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/"
+  webServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080/"
     {{- else }}
-  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650/"
-  webServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080/"
+  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/"
+  webServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080/"
     {{- end }}
   {{- end }}
 {{- range $key, $val := $.Values.bastion.configData }}

--- a/helm-chart-sources/pulsar/templates/beam/beamwh-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/beam/beamwh-deployment.yaml
@@ -224,9 +224,9 @@ spec:
             value: "{{ .Values.pulsarBeam.tlsCaPath }}/{{ .Values.pulsarBeam.tlsCaCert }}"
             {{- end }}
           - name: PulsarBrokerURL
-            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
+            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651"
           {{- else }}
           - name: PulsarBrokerURL
-            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
+            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650"
           {{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/beam/beamwh-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/beam/beamwh-deployment.yaml
@@ -224,9 +224,9 @@ spec:
             value: "{{ .Values.pulsarBeam.tlsCaPath }}/{{ .Values.pulsarBeam.tlsCaCert }}"
             {{- end }}
           - name: PulsarBrokerURL
-            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:6651"
+            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
           {{- else }}
           - name: PulsarBrokerURL
-            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:6650"
+            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
           {{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-configmap.yaml
@@ -31,15 +31,15 @@ data:
   zkServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- end }}
     {{- end }}
   # disable auto recovery on bookies since we will start AutoRecovery in separated pods

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-configmap.yaml
@@ -31,15 +31,15 @@ data:
   zkServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- end }}
     {{- end }}
   # disable auto recovery on bookies since we will start AutoRecovery in separated pods

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -32,29 +32,29 @@ data:
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
       {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
       {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
       {{- end }}
     {{- else }}
       {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
       {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
       {{- end }}
     {{- end }}
   configurationStoreServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- end }}
     {{- end }}
   clusterName: {{ template "pulsar.fullname" . }}
@@ -89,7 +89,7 @@ data:
   authenticationProviders: "{{ .Values.broker.authenticationProviders }}"
   {{- end }}
   {{- if .Values.keycloak.enabled }}
-  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ template "pulsar.serviceDnsSuffix" . }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
   {{- end }}
   {{- end }}
 {{- if .Values.enableTls }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -32,29 +32,29 @@ data:
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
       {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
       {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
       {{- end }}
     {{- else }}
       {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
       {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
       {{- end }}
     {{- end }}
   configurationStoreServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- end }}
     {{- end }}
   clusterName: {{ template "pulsar.fullname" . }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -32,29 +32,29 @@ data:
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- end }}
     {{- end }}
   configurationStoreServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- end }}
     {{- end }}
   clusterName: {{ template "pulsar.fullname" . }}
@@ -89,7 +89,7 @@ data:
   authenticationProviders: "{{ .Values.brokerSts.authenticationProviders }}"
   {{- end }}
   {{- if .Values.keycloak.enabled }}
-  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ template "pulsar.serviceDnsSuffix" . }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
   {{- end }}
   {{- end }}
 {{- if .Values.enableTls }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -32,29 +32,29 @@ data:
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2281
+    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2181
+    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- end }}
     {{- end }}
   configurationStoreServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2181
+    { template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- end }}
     {{- end }}
   clusterName: {{ template "pulsar.fullname" . }}

--- a/helm-chart-sources/pulsar/templates/cert-manager/self-signed-cert-per-component.yaml
+++ b/helm-chart-sources/pulsar/templates/cert-manager/self-signed-cert-per-component.yaml
@@ -37,7 +37,7 @@ spec:
 {{ toYaml .Values.tls.ssCaCert.certSpec.privateKey | indent 4 }}
   {{- end }}
   secretName: "{{ template "pulsar.fullname" . }}-ss-ca"
-  commonName: "{{ .Release.Namespace }}.svc.cluster.local"
+  commonName: "{{ template "pulsar.serviceDnsSuffix" . }}"
   usages:
     - server auth
     - client auth
@@ -70,10 +70,10 @@ spec:
   # The wildcard names are needed to connect directly to the broker.
   # The non-wildcard broker names are needed when calling the topic lookup service.
   dnsNames:
-    - "*.{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "*.{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "*.{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}"
     - "*.{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}"
-    - "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}"
   issuerRef:
@@ -95,10 +95,10 @@ spec:
   secretName: {{ .Values.tls.bookkeeper.tlsSecretName }}
   # The wildcard names are needed to connect directly to the broker.
   dnsNames:
-    - "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ .Release.Namespace }}"
     - "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-    - "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ .Release.Namespace }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
   issuerRef:
@@ -119,7 +119,7 @@ spec:
   {{- end }}
   secretName: {{ required "Must set .Values.tls.proxy.tlsSecretName to create certificates for proxy" .Values.tls.proxy.tlsSecretName }}
   dnsNames:
-    - "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   issuerRef:
@@ -142,13 +142,13 @@ spec:
   # The DNS names ending in "-ca" are meant for client access. The wildcard names are used for zookeeper to zookeeper
   # networking.
   dnsNames:
-    - "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local"
+    - "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca"
-    - "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }}"
     - "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-    - "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Release.Namespace }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   issuerRef:

--- a/helm-chart-sources/pulsar/templates/cert-manager/self-signed-cert-per-component.yaml
+++ b/helm-chart-sources/pulsar/templates/cert-manager/self-signed-cert-per-component.yaml
@@ -171,13 +171,13 @@ spec:
   # The DNS names ending in "-ca" are meant for client access. The wildcard names are used for zookeeper to zookeeper
   # networking.
   dnsNames:
-    - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local"
+    - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ .Release.Namespace }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca"
-    - "*.{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "*.{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "*.{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}"
     - "*.{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"
-    - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}"
   issuerRef:
@@ -219,7 +219,7 @@ spec:
   {{- end }}
   secretName: {{ required "Must set .Values.tls.pulsarAdminConsole.tlsSecretName to create certificates for pulsarAdminConsole" .Values.tls.pulsarAdminConsole.tlsSecretName }}
   dnsNames:
-    - "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}.{{ .Release.Namespace }}"
     - "{{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}"
   issuerRef:

--- a/helm-chart-sources/pulsar/templates/cert-manager/self-signed-issuer.yaml
+++ b/helm-chart-sources/pulsar/templates/cert-manager/self-signed-issuer.yaml
@@ -97,7 +97,7 @@ metadata:
 spec:
   secretName: "keycloak-{{ .Values.tlsSecretName }}"
   dnsNames:
-    - "{{ template "pulsar.keycloak.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+    - "{{ template "pulsar.keycloak.fullname" . }}.{{ template "pulsar.serviceDnsSuffix" . }}"
     - "{{ template "pulsar.keycloak.fullname" . }}.{{ .Release.Namespace }}"
     - "{{ template "pulsar.keycloak.fullname" . }}"
   {{- if .Values.createCertificates.selfSigned.includeDns }}

--- a/helm-chart-sources/pulsar/templates/cert-manager/self-signed-issuer.yaml
+++ b/helm-chart-sources/pulsar/templates/cert-manager/self-signed-issuer.yaml
@@ -33,7 +33,7 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
 spec:
   secretName: "{{ template "pulsar.fullname" . }}-ss-ca"
-  commonName: "{{ .Release.Namespace }}.svc.cluster.local"
+  commonName: "{{ template "pulsar.serviceDnsSuffix" . }}"
   usages:
     - server auth
     - client auth
@@ -61,16 +61,16 @@ spec:
   # The wildcard names are needed to connect directly to the broker pods and will only work when the broker is deployed
   # as a StatefulSet.
   dnsNames:
-  - "*.{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+  - "*.{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
   - "*.{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}"
   - "*.{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}"
-  - "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+  - "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
   - "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}"
   - "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}"
-  - "{{ template "pulsar.fullname" . }}-proxy.{{ .Release.Namespace }}.svc.cluster.local"
+  - "{{ template "pulsar.fullname" . }}-proxy.{{ template "pulsar.serviceDnsSuffix" . }}"
   - "{{ template "pulsar.fullname" . }}-proxy.{{ .Release.Namespace }}"
   - "{{ template "pulsar.fullname" . }}-proxy"
-  - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local"
+  - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}"
   - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ .Release.Namespace }}"
   - "{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca"
   {{- if .Values.createCertificates.selfSigned.includeDns }}

--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -40,20 +40,20 @@ data:
       {{- if .Values.extra.zookeepernp }}
     configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
       {{- else }}
-    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
       {{- end }}
     {{- end }}
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
       {{- if .Values.extra.zookeepernp }}
-    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
       {{- else }}
-    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
       {{- end }}
     {{- else }}
       {{- if .Values.extra.zookeepernp }}
-    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
       {{- else }}
-    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
       {{- end }}
     {{- end }}
     zooKeeperSessionTimeoutMillis: 30000
@@ -83,11 +83,11 @@ data:
     tlsKeyStore: "/pulsar/tls.keystore.jks"
     tlsTrustStore: "/pulsar/tls.truststore.jks"
     tlsEnableHostnameVerification: "{{ .Values.tls.function.enableHostnameVerification }}"
-    pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
-    pulsarWebServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
+    pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651"
+    pulsarWebServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443"
     {{- else }}
-    pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
-    pulsarWebServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
+    pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650"
+    pulsarWebServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080"
     {{- end }}
     numFunctionPackageReplicas: "{{ .Values.function.functionReplicaCount }}"
     downloadDirectory: "/tmp/pulsar_functions"
@@ -111,7 +111,7 @@ data:
     stateStorageServiceUrl: {{ .Values.function.stateStorageUrlOverride }}
     {{- else }}
     {{- if .Values.extra.stateStorage }}
-    stateStorageServiceUrl: "bk://{{ template "pulsar.fullname" . }}-{{ .Values.stateStorage.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:4181"
+    stateStorageServiceUrl: "bk://{{ template "pulsar.fullname" . }}-{{ .Values.stateStorage.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:4181"
     {{- else }}
     stateStorageServiceUrl: {{ include "pulsar.bkConnectStringOne" . }}
     {{- end }}
@@ -125,7 +125,7 @@ data:
     properties:
       tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
       {{- if .Values.keycloak.enabled }}
-      openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
+      openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ template "pulsar.serviceDnsSuffix" . }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
       {{- end }}
       {{- if .Values.function.customProperties }}
 {{ toYaml .Values.function.customProperties | indent 6 }}
@@ -166,10 +166,10 @@ data:
       submittingInsidePod: true
       # setting the pulsar service url that pulsar function should use to connect to pulsar
       # if it is not set, it will use the pulsar service url configured in worker service
-      pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/"
+      pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650/"
       # setting the pulsar admin url that pulsar function should use to connect to pulsar
       # if it is not set, it will use the pulsar admin url configured in worker service
-      pulsarAdminUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}.svc.cluster.local:6750/"
+      pulsarAdminUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6750/"
       # the custom labels that function worker uses to select the nodes for pods
       #customLabels:
       # the directory for dropping extra function dependencies

--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -32,28 +32,28 @@ data:
   functions_worker.yml: |-
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
       {{- if .Values.extra.zookeepernp }}
-    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2281
+    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
       {{- else }}
-    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281
+    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
       {{- end }}
     {{- else }}
       {{- if .Values.extra.zookeepernp }}
-    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2181
+    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
       {{- else }}
-    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
+    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
       {{- end }}
     {{- end }}
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
       {{- if .Values.extra.zookeepernp }}
-    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2281
+    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
       {{- else }}
-    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281
+    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
       {{- end }}
     {{- else }}
       {{- if .Values.extra.zookeepernp }}
-    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2181
+    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
       {{- else }}
-    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
+    zookeeperServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
       {{- end }}
     {{- end }}
     zooKeeperSessionTimeoutMillis: 30000
@@ -83,11 +83,11 @@ data:
     tlsKeyStore: "/pulsar/tls.keystore.jks"
     tlsTrustStore: "/pulsar/tls.truststore.jks"
     tlsEnableHostnameVerification: "{{ .Values.tls.function.enableHostnameVerification }}"
-    pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:6651"
-    pulsarWebServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443"
+    pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
+    pulsarWebServiceUrl: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
     {{- else }}
-    pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650"
-    pulsarWebServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080"
+    pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
+    pulsarWebServiceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
     {{- end }}
     numFunctionPackageReplicas: "{{ .Values.function.functionReplicaCount }}"
     downloadDirectory: "/tmp/pulsar_functions"
@@ -111,7 +111,7 @@ data:
     stateStorageServiceUrl: {{ .Values.function.stateStorageUrlOverride }}
     {{- else }}
     {{- if .Values.extra.stateStorage }}
-    stateStorageServiceUrl: "bk://{{ template "pulsar.fullname" . }}-{{ .Values.stateStorage.component }}-ca:4181"
+    stateStorageServiceUrl: "bk://{{ template "pulsar.fullname" . }}-{{ .Values.stateStorage.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:4181"
     {{- else }}
     stateStorageServiceUrl: {{ include "pulsar.bkConnectStringOne" . }}
     {{- end }}
@@ -166,10 +166,10 @@ data:
       submittingInsidePod: true
       # setting the pulsar service url that pulsar function should use to connect to pulsar
       # if it is not set, it will use the pulsar service url configured in worker service
-      pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650/"
+      pulsarServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/"
       # setting the pulsar admin url that pulsar function should use to connect to pulsar
       # if it is not set, it will use the pulsar admin url configured in worker service
-      pulsarAdminUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}:6750/"
+      pulsarAdminUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}.svc.cluster.local:6750/"
       # the custom labels that function worker uses to select the nodes for pods
       #customLabels:
       # the directory for dropping extra function dependencies

--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -32,13 +32,13 @@ data:
   functions_worker.yml: |-
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
       {{- if .Values.extra.zookeepernp }}
-    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
       {{- else }}
-    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
       {{- end }}
     {{- else }}
       {{- if .Values.extra.zookeepernp }}
-    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
       {{- else }}
     configurationStoreServers: {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -31,37 +31,37 @@ metadata:
 data:
   {{- if .Values.proxy.disableZookeeperDiscovery }}
   {{- if .Values.proxy.useStsBrokersForDiscovery }}
-  brokerServiceURL: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
-  brokerServiceURLTLS: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
-  brokerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
-  brokerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
+  brokerServiceURL: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650"
+  brokerServiceURLTLS: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651"
+  brokerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080"
+  brokerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443"
   {{- else }}
-  brokerServiceURL: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
-  brokerServiceURLTLS: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
-  brokerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
-  brokerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
+  brokerServiceURL: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650"
+  brokerServiceURLTLS: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651"
+  brokerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080"
+  brokerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443"
   {{- end }}
   {{- end }}
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- end }}
     {{- end }}
   configurationStoreServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -31,47 +31,47 @@ metadata:
 data:
   {{- if .Values.proxy.disableZookeeperDiscovery }}
   {{- if .Values.proxy.useStsBrokersForDiscovery }}
-  brokerServiceURL: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:6650"
-  brokerServiceURLTLS: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:6651"
-  brokerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8080"
-  brokerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443"
+  brokerServiceURL: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
+  brokerServiceURLTLS: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
+  brokerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
+  brokerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
   {{- else }}
-  brokerServiceURL: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650"
-  brokerServiceURLTLS: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6651"
-  brokerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080"
-  brokerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8443"
+  brokerServiceURL: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
+  brokerServiceURLTLS: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
+  brokerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
+  brokerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
   {{- end }}
   {{- end }}
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- end }}
     {{- end }}
   configurationStoreServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
     {{- end }}
     {{- end }}
   {{- if .Values.extra.function }}
-  functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca:6750"
+  functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:6750"
   {{- end }}
 {{- if .Values.enableTls }}
   tlsEnabledWithKeyStore: "true"
@@ -105,9 +105,9 @@ data:
   {{- end }}
   {{- if .Values.extra.function }}
   {{- if or .Values.tls.function.enabled .Values.tls.proxy.enableTlsWithBroker }}
-  functionWorkerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca:6751"
+  functionWorkerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:6751"
   {{- else }}
-  functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca:6750"
+  functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:6750"
   {{- end }}
   {{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -65,13 +65,13 @@ data:
     {{- end }}
     {{- else }}
     {{- if .Values.extra.zookeepernp }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181,{{ template "pulsar.fullname" . }}-{{ .Values.zookeepernp.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- else }}
-    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181
+    {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- end }}
     {{- end }}
   {{- if .Values.extra.function }}
-  functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:6750"
+  functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:6750"
   {{- end }}
 {{- if .Values.enableTls }}
   tlsEnabledWithKeyStore: "true"
@@ -105,9 +105,9 @@ data:
   {{- end }}
   {{- if .Values.extra.function }}
   {{- if or .Values.tls.function.enabled .Values.tls.proxy.enableTlsWithBroker }}
-  functionWorkerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:6751"
+  functionWorkerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:6751"
   {{- else }}
-  functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:6750"
+  functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:6750"
   {{- end }}
   {{- end }}
 {{- end }}
@@ -121,7 +121,7 @@ data:
   authenticationProviders: "{{ .Values.proxy.authenticationProviders }}"
   {{- end }}
   {{- if .Values.keycloak.enabled }}
-  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ template "pulsar.serviceDnsSuffix" . }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
   {{- end }}
   tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -364,7 +364,7 @@ spec:
           - name: TARGET_URL
             value: ws://localhost:8000
           - name: FUNC_URL
-            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}.svc.cluster.local:6750"
+            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6750"
           - name: TOKEN_SERVER_URL
             value: http://localhost:8084
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -464,10 +464,10 @@ spec:
             value: "{{ .Values.pulsarBeam.tlsCaPath }}/{{ .Values.pulsarBeam.tlsCaCert }}"
             {{- end }}
           - name: PulsarBrokerURL
-            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
+            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651"
           {{- else }}
           - name: PulsarBrokerURL
-            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
+            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650"
           {{- end }}
 {{- end }}
 {{- if .Values.extra.burnell }}
@@ -503,9 +503,9 @@ spec:
           - name: WebsocketURL
             value: {{ .Values.burnell.wsUrl | default "ws://localhost:8000" }}
           - name: BrokerProxyURL
-            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
+            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080"
           - name: FunctionProxyURL
-            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}.svc.cluster.local:6750"
+            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6750"
           {{- if .Values.enableTokenAuth }}
           - name: SuperRoles
             value: {{ .Values.superUserRoles }}
@@ -518,7 +518,7 @@ spec:
           - name: HTTPAuthImpl
             value: {{ .Values.burnell.token }}
           - name: PulsarURL
-            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
+            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650"
           {{- if .Values.enableTokenAuth }}
           - name: PulsarPublicKey
             value: "/pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
@@ -546,6 +546,6 @@ spec:
           - name: AdminRestPrefix
             value: {{ .Values.burnell.adminRestAPIPrefix | default "/admin/v2" }}
           - name: FunctionWorkerDomain
-            value: ".{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}.svc.cluster.local"
+            value: ".{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ template "pulsar.serviceDnsSuffix" . }}"
 {{- end }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -364,7 +364,7 @@ spec:
           - name: TARGET_URL
             value: ws://localhost:8000
           - name: FUNC_URL
-            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}:6750"
+            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}.svc.cluster.local:6750"
           - name: TOKEN_SERVER_URL
             value: http://localhost:8084
 {{- end }}
@@ -464,10 +464,10 @@ spec:
             value: "{{ .Values.pulsarBeam.tlsCaPath }}/{{ .Values.pulsarBeam.tlsCaCert }}"
             {{- end }}
           - name: PulsarBrokerURL
-            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:6651"
+            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
           {{- else }}
           - name: PulsarBrokerURL
-            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:6650"
+            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
           {{- end }}
 {{- end }}
 {{- if .Values.extra.burnell }}
@@ -503,9 +503,9 @@ spec:
           - name: WebsocketURL
             value: {{ .Values.burnell.wsUrl | default "ws://localhost:8000" }}
           - name: BrokerProxyURL
-            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080"
+            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
           - name: FunctionProxyURL
-            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}:6750"
+            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}.{{ .Release.Namespace }}.svc.cluster.local:6750"
           {{- if .Values.enableTokenAuth }}
           - name: SuperRoles
             value: {{ .Values.superUserRoles }}
@@ -518,7 +518,7 @@ spec:
           - name: HTTPAuthImpl
             value: {{ .Values.burnell.token }}
           - name: PulsarURL
-            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650"
+            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
           {{- if .Values.enableTokenAuth }}
           - name: PulsarPublicKey
             value: "/pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -30,22 +30,22 @@ metadata:
     cluster: {{ template "pulsar.fullname" . }}
 data:
   {{- if .Values.proxy.disableZookeeperDiscovery }}
-  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
-  brokerServiceUrlTls: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
-  serviceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
-  serviceUrlTls: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
+  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650"
+  brokerServiceUrlTls: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651"
+  serviceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080"
+  serviceUrlTls: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443"
   {{- end }}
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
-    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281"
+    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281"
     {{- else }}
-    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181"
+    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181"
     {{- end }}
   configurationStoreServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
-    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281"
+    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281"
     {{- else }}
-    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181"
+    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181"
     {{- end }}
   clusterName: {{ template "pulsar.fullname" . }}
   webServicePort: "{{ .Values.proxy.wsProxyPort }}"
@@ -58,7 +58,7 @@ data:
   authorizationEnabled: "true"
   superUserRoles: "{{ .Values.superUserRoles }}"
   {{- if .Values.keycloak.enabled }}
-  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}.svc.cluster.local{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
+  PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ template "pulsar.serviceDnsSuffix" . }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"
   {{- end }}
   {{- end }}
 {{- if .Values.enableTls }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -30,22 +30,22 @@ metadata:
     cluster: {{ template "pulsar.fullname" . }}
 data:
   {{- if .Values.proxy.disableZookeeperDiscovery }}
-  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650"
-  brokerServiceUrlTls: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6651"
-  serviceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080"
-  serviceUrlTls: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8443"
+  brokerServiceUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
+  brokerServiceUrlTls: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
+  serviceUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
+  serviceUrlTls: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
   {{- end }}
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
-    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281"
+    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281"
     {{- else }}
-    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181"
+    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181"
     {{- end }}
   configurationStoreServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
-    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281"
+    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281"
     {{- else }}
-    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181"
+    "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181"
     {{- end }}
   clusterName: {{ template "pulsar.fullname" . }}
   webServicePort: "{{ .Values.proxy.wsProxyPort }}"

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-configmap.yaml
@@ -55,9 +55,9 @@ data:
       {{- if .Values.pulsarHeartbeat.config.broker }}
       intervalSeconds: {{ .Values.pulsarHeartbeat.config.broker.intervalSeconds | default 45 }}
       {{- if .Values.enableTls }}
-      inclusterRestURL: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
+      inclusterRestURL: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443"
       {{- else }}
-      inclusterRestURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
+      inclusterRestURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080"
       {{- end }}
       alertPolicy:
         Ceiling: {{ .Values.pulsarHeartbeat.config.broker.alertCeiling | default 5 }}
@@ -70,9 +70,9 @@ data:
       clusters:
         - name: {{ template "pulsar.fullname" . }}
           {{- if .Values.enableTls }}
-          url: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
+          url: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443"
           {{- else }}
-          url: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
+          url: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080"
           {{- end }}
           alertPolicy:
             Ceiling: {{ .Values.pulsarHeartbeat.config.adminRest.alertCeiling | default 5 }}
@@ -85,9 +85,9 @@ data:
         name: "pubsub-latency-incluster-{{ template "pulsar.fullname" . }}"
         intervalSeconds: {{ .Values.pulsarHeartbeat.config.latencyTest.intervalSeconds | default 60 }}
         {{- if .Values.enableTls }}
-        pulsarUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
+        pulsarUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651"
         {{- else }}
-        pulsarUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
+        pulsarUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650"
         {{- end }}
         topicName: {{ .Values.pulsarHeartbeat.config.latencyTest.intervalSeconds | default "persistent://public/default/pubsub-latency-test" }}
         payloadSizes: [15B]

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-configmap.yaml
@@ -55,9 +55,9 @@ data:
       {{- if .Values.pulsarHeartbeat.config.broker }}
       intervalSeconds: {{ .Values.pulsarHeartbeat.config.broker.intervalSeconds | default 45 }}
       {{- if .Values.enableTls }}
-      inclusterRestURL: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443"
+      inclusterRestURL: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
       {{- else }}
-      inclusterRestURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080"
+      inclusterRestURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
       {{- end }}
       alertPolicy:
         Ceiling: {{ .Values.pulsarHeartbeat.config.broker.alertCeiling | default 5 }}
@@ -70,9 +70,9 @@ data:
       clusters:
         - name: {{ template "pulsar.fullname" . }}
           {{- if .Values.enableTls }}
-          url: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443"
+          url: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
           {{- else }}
-          url: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080"
+          url: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
           {{- end }}
           alertPolicy:
             Ceiling: {{ .Values.pulsarHeartbeat.config.adminRest.alertCeiling | default 5 }}
@@ -85,9 +85,9 @@ data:
         name: "pubsub-latency-incluster-{{ template "pulsar.fullname" . }}"
         intervalSeconds: {{ .Values.pulsarHeartbeat.config.latencyTest.intervalSeconds | default 60 }}
         {{- if .Values.enableTls }}
-        pulsarUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:6651"
+        pulsarUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
         {{- else }}
-        pulsarUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650"
+        pulsarUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
         {{- end }}
         topicName: {{ .Values.pulsarHeartbeat.config.latencyTest.intervalSeconds | default "persistent://public/default/pubsub-latency-test" }}
         payloadSizes: [15B]

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
@@ -83,9 +83,9 @@ spec:
         args:
           - >-
             {{- if .Values.enableTls }}
-            until curl --connect-timeout 5 --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443; do
+            until curl --connect-timeout 5 --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
             {{- else }}
-            until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080; do
+            until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do
             {{- end }}
               sleep 3;
             done;
@@ -125,9 +125,9 @@ spec:
             value: "{{ template "pulsar.fullname" . }}"
           - name: BrokerProxyURL
             {{- if .Values.enableTls }}
-            value: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
+            value: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443"
             {{- else }}
-            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
+            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080"
             {{- end }}
           {{- if .Values.enableTokenAuth }}
           - name: PulsarToken
@@ -138,9 +138,9 @@ spec:
           {{- end }}
           - name: PulsarURL
             {{- if .Values.enableTls }}
-            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
+            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651"
             {{- else }}
-            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
+            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650"
             {{- end }}
       {{- with .Values.pulsarHeartbeat.nodeSelector }}
       nodeSelector:

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
@@ -83,9 +83,9 @@ spec:
         args:
           - >-
             {{- if .Values.enableTls }}
-            until curl --connect-timeout 5 --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443; do
+            until curl --connect-timeout 5 --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443; do
             {{- else }}
-            until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080; do
+            until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080; do
             {{- end }}
               sleep 3;
             done;
@@ -125,9 +125,9 @@ spec:
             value: "{{ template "pulsar.fullname" . }}"
           - name: BrokerProxyURL
             {{- if .Values.enableTls }}
-            value: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:8443"
+            value: "https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443"
             {{- else }}
-            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080"
+            value: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080"
             {{- end }}
           {{- if .Values.enableTokenAuth }}
           - name: PulsarToken
@@ -138,9 +138,9 @@ spec:
           {{- end }}
           - name: PulsarURL
             {{- if .Values.enableTls }}
-            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}:6651"
+            value: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651"
             {{- else }}
-            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650"
+            value: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650"
             {{- end }}
       {{- with .Values.pulsarHeartbeat.nodeSelector }}
       nodeSelector:

--- a/helm-chart-sources/pulsar/templates/pulsarSql/configmap-coordinator.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/configmap-coordinator.yaml
@@ -62,8 +62,8 @@ data:
   pulsar.properties: |
     connector.name=pulsar
     {{- if .Values.enableTls }}
-    # pulsar.broker-service-url=https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443
-    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+    # pulsar.broker-service-url=https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443
+    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080
     pulsar.tls-allow-insecure-connection = false
     pulsar.tls-hostname-verification-enable = false
     {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled .Values.createCertificates.selfSignedPerComponent.enabled }}
@@ -72,7 +72,7 @@ data:
     pulsar.tls-trust-cert-file-path = {{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}
     {{- end }}
     {{- else }}
-    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080
     {{- end }}
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     pulsar.zookeeper-uri={{ include "pulsar.zkConnectStringTls" . }}

--- a/helm-chart-sources/pulsar/templates/pulsarSql/configmap-coordinator.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/configmap-coordinator.yaml
@@ -62,8 +62,8 @@ data:
   pulsar.properties: |
     connector.name=pulsar
     {{- if .Values.enableTls }}
-    # pulsar.broker-service-url=https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8443
-    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080
+    # pulsar.broker-service-url=https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443
+    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080
     pulsar.tls-allow-insecure-connection = false
     pulsar.tls-hostname-verification-enable = false
     {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled .Values.createCertificates.selfSignedPerComponent.enabled }}
@@ -72,7 +72,7 @@ data:
     pulsar.tls-trust-cert-file-path = {{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}
     {{- end }}
     {{- else }}
-    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080
+    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080
     {{- end }}
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     pulsar.zookeeper-uri={{ include "pulsar.zkConnectStringTls" . }}

--- a/helm-chart-sources/pulsar/templates/pulsarSql/configmap-worker.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/configmap-worker.yaml
@@ -57,7 +57,7 @@ data:
   pulsar.properties: |
     connector.name=pulsar
     {{- if .Values.enableTls }}
-    pulsar.broker-service-url=https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8443
+    pulsar.broker-service-url=https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443
     pulsar.tls-allow-insecure-connection = false
     pulsar.tls-hostname-verification-enable = false
     {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled .Values.createCertificates.selfSignedPerComponent.enabled }}
@@ -66,7 +66,7 @@ data:
     pulsar.tls-trust-cert-file-path = {{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}
     {{- end }}
     {{- else }}
-    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080
+    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080
     {{- end }}
     # Can only use 1 Zookeeper as workaround for #6947
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}

--- a/helm-chart-sources/pulsar/templates/pulsarSql/configmap-worker.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/configmap-worker.yaml
@@ -57,7 +57,7 @@ data:
   pulsar.properties: |
     connector.name=pulsar
     {{- if .Values.enableTls }}
-    pulsar.broker-service-url=https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443
+    pulsar.broker-service-url=https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443
     pulsar.tls-allow-insecure-connection = false
     pulsar.tls-hostname-verification-enable = false
     {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled .Values.createCertificates.selfSignedPerComponent.enabled }}
@@ -66,7 +66,7 @@ data:
     pulsar.tls-trust-cert-file-path = {{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}
     {{- end }}
     {{- else }}
-    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+    pulsar.broker-service-url=http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080
     {{- end }}
     # Can only use 1 Zookeeper as workaround for #6947
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}

--- a/helm-chart-sources/pulsar/templates/tests/beam-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/beam-test.yaml
@@ -48,9 +48,9 @@ data:
     exit_if_error $? "Create subscription failed"
 
     echo "Send 3 messages using curl"
-    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 1" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
-    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 2" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
-    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 3" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
+    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 1" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8085/v1/firehose
+    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 2" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8085/v1/firehose
+    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 3" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8085/v1/firehose
     exit_if_error $? "Sending e messages using curl failed"
 
     echo "Consume the messages"
@@ -83,9 +83,9 @@ spec:
           /pulsar/tests/test.sh
     env:
     - name: webServiceUrl
-      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080/
+      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080/
     - name: brokerServiceUrl
-      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/
+      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650/
     volumeMounts:
       - name: test-scripts
         mountPath: /pulsar/tests

--- a/helm-chart-sources/pulsar/templates/tests/beam-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/beam-test.yaml
@@ -48,9 +48,9 @@ data:
     exit_if_error $? "Create subscription failed"
 
     echo "Send 3 messages using curl"
-    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 1" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8085/v1/firehose
-    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 2" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8085/v1/firehose
-    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 3" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8085/v1/firehose
+    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 1" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
+    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 2" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
+    curl -q -X POST -H "TopicFn: $TOPIC"  -d "message 3" http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
     exit_if_error $? "Sending e messages using curl failed"
 
     echo "Consume the messages"
@@ -83,9 +83,9 @@ spec:
           /pulsar/tests/test.sh
     env:
     - name: webServiceUrl
-      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080/
+      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080/
     - name: brokerServiceUrl
-      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650/
+      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/
     volumeMounts:
       - name: test-scripts
         mountPath: /pulsar/tests

--- a/helm-chart-sources/pulsar/templates/tests/offload-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/offload-test.yaml
@@ -91,9 +91,9 @@ spec:
           /pulsar/tests/test.sh
     env:
     - name: webServiceUrl
-      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080/
+      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.svc.cluster.local:8080/
     - name: brokerServiceUrl
-      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650/
+      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.svc.cluster.local:6650/
     volumeMounts:
       - name: test-scripts
         mountPath: /pulsar/tests

--- a/helm-chart-sources/pulsar/templates/tests/offload-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/offload-test.yaml
@@ -91,9 +91,9 @@ spec:
           /pulsar/tests/test.sh
     env:
     - name: webServiceUrl
-      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.svc.cluster.local:8080/
+      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080/
     - name: brokerServiceUrl
-      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.svc.cluster.local:6650/
+      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650/
     volumeMounts:
       - name: test-scripts
         mountPath: /pulsar/tests

--- a/helm-chart-sources/pulsar/templates/tests/plain-text-broker.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/plain-text-broker.yaml
@@ -28,7 +28,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-admin"]
-    args: ["--admin-url", "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080", "tenants", "list"]
+    args: ["--admin-url", "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080", "tenants", "list"]
   # Do not restart containers after they exit
   restartPolicy: Never
 ---
@@ -44,7 +44,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-client"]
-    args: ["--url", "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650", "produce", "-m", "hello", "public/default/test"]
+    args: ["--url", "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650", "produce", "-m", "hello", "public/default/test"]
   # Do not restart containers after they exit
   restartPolicy: Never
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/tests/plain-text-broker.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/plain-text-broker.yaml
@@ -28,7 +28,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-admin"]
-    args: ["--admin-url", "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080", "tenants", "list"]
+    args: ["--admin-url", "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080", "tenants", "list"]
   # Do not restart containers after they exit
   restartPolicy: Never
 ---
@@ -44,7 +44,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-client"]
-    args: ["--url", "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650", "produce", "-m", "hello", "public/default/test"]
+    args: ["--url", "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650", "produce", "-m", "hello", "public/default/test"]
   # Do not restart containers after they exit
   restartPolicy: Never
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/tests/plain-text-proxy.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/plain-text-proxy.yaml
@@ -29,7 +29,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-admin"]
-    args: ["--admin-url", "http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8080", "tenants", "list"]
+    args: ["--admin-url", "http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080", "tenants", "list"]
   # Do not restart containers after they exit
   restartPolicy: Never
 ---
@@ -45,7 +45,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-client"]
-    args: ["--url", "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:6650", "produce", "-m", "hello", "public/default/test"]
+    args: ["--url", "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650", "produce", "-m", "hello", "public/default/test"]
   # Do not restart containers after they exit
   restartPolicy: Never
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/tests/plain-text-proxy.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/plain-text-proxy.yaml
@@ -29,7 +29,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-admin"]
-    args: ["--admin-url", "http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080", "tenants", "list"]
+    args: ["--admin-url", "http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080", "tenants", "list"]
   # Do not restart containers after they exit
   restartPolicy: Never
 ---
@@ -45,7 +45,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-client"]
-    args: ["--url", "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650", "produce", "-m", "hello", "public/default/test"]
+    args: ["--url", "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650", "produce", "-m", "hello", "public/default/test"]
   # Do not restart containers after they exit
   restartPolicy: Never
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/tests/schema-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/schema-test.yaml
@@ -163,9 +163,9 @@ spec:
           /pulsar/tests/test.sh
     env:
     - name: webServiceUrl
-      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8080/
+      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080/
     - name: brokerServiceUrl
-      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6650/
+      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/
     volumeMounts:
       - name: test-scripts
         mountPath: /pulsar/tests

--- a/helm-chart-sources/pulsar/templates/tests/schema-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/schema-test.yaml
@@ -163,9 +163,9 @@ spec:
           /pulsar/tests/test.sh
     env:
     - name: webServiceUrl
-      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080/
+      value: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080/
     - name: brokerServiceUrl
-      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/
+      value: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650/
     volumeMounts:
       - name: test-scripts
         mountPath: /pulsar/tests

--- a/helm-chart-sources/pulsar/templates/tests/tls-beam-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-beam-test.yaml
@@ -48,9 +48,9 @@ data:
     exit_if_error $? "Create subscription failed"
 
     echo "Send 3 messages using curl"
-    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 1" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
-    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 2" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
-    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 3" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
+    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 1" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8085/v1/firehose
+    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 2" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8085/v1/firehose
+    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 3" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8085/v1/firehose
     exit_if_error $? "Sending e messages using curl failed"
 
     echo "Consume the messages"
@@ -83,9 +83,9 @@ spec:
           /pulsar/tests/test.sh
     env:
     - name: webServiceUrl
-      value: https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443/
+      value: https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443/
     - name: brokerServiceUrl
-      value: pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651/
+      value: pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651/
     {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled .Values.createCertificates.selfSignedPerComponent.enabled }}
     - name: tlsTrustCertsFilePath
       value: /pulsar/certs/ca.crt

--- a/helm-chart-sources/pulsar/templates/tests/tls-beam-test.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-beam-test.yaml
@@ -48,9 +48,9 @@ data:
     exit_if_error $? "Create subscription failed"
 
     echo "Send 3 messages using curl"
-    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 1" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8085/v1/firehose
-    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 2" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8085/v1/firehose
-    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 3" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8085/v1/firehose
+    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 1" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
+    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 2" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
+    curl -k -s -X POST -H "TopicFn: $TOPIC"  -d "message 3" https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8085/v1/firehose
     exit_if_error $? "Sending e messages using curl failed"
 
     echo "Consume the messages"
@@ -83,9 +83,9 @@ spec:
           /pulsar/tests/test.sh
     env:
     - name: webServiceUrl
-      value: https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8443/
+      value: https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443/
     - name: brokerServiceUrl
-      value: pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6651/
+      value: pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651/
     {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled .Values.createCertificates.selfSignedPerComponent.enabled }}
     - name: tlsTrustCertsFilePath
       value: /pulsar/certs/ca.crt

--- a/helm-chart-sources/pulsar/templates/tests/tls-broker.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-broker.yaml
@@ -29,7 +29,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-admin"]
-    args: ["--admin-url", "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:8443", "tenants", "list"]
+    args: ["--admin-url", "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443", "tenants", "list"]
   # Do not restart containers after they exit
   restartPolicy: Never
 ---
@@ -63,7 +63,7 @@ spec:
       cat /pulsar/token-superuser/superuser.jwt | tr -d '\n' > /pulsar/token-superuser-stripped.jwt &&
       {{- end }}
       bin/apply-config-from-env.py conf/client.conf &&
-      /pulsar/bin/pulsar-client --url pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:6651 produce -m hello public/default/test
+      /pulsar/bin/pulsar-client --url pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651 produce -m hello public/default/test
     volumeMounts:
       - name: certs
         mountPath: /pulsar/certs

--- a/helm-chart-sources/pulsar/templates/tests/tls-broker.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-broker.yaml
@@ -29,7 +29,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-admin"]
-    args: ["--admin-url", "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443", "tenants", "list"]
+    args: ["--admin-url", "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443", "tenants", "list"]
   # Do not restart containers after they exit
   restartPolicy: Never
 ---
@@ -63,7 +63,7 @@ spec:
       cat /pulsar/token-superuser/superuser.jwt | tr -d '\n' > /pulsar/token-superuser-stripped.jwt &&
       {{- end }}
       bin/apply-config-from-env.py conf/client.conf &&
-      /pulsar/bin/pulsar-client --url pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651 produce -m hello public/default/test
+      /pulsar/bin/pulsar-client --url pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651 produce -m hello public/default/test
     volumeMounts:
       - name: certs
         mountPath: /pulsar/certs

--- a/helm-chart-sources/pulsar/templates/tests/tls-proxy.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-proxy.yaml
@@ -30,7 +30,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-admin"]
-    args: ["--admin-url", "https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:8443", "tenants", "list"]
+    args: ["--admin-url", "https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443", "tenants", "list"]
   # Do not restart containers after they exit
   restartPolicy: Never
 ---
@@ -64,7 +64,7 @@ spec:
       cat /pulsar/token-superuser/superuser.jwt | tr -d '\n' > /pulsar/token-superuser-stripped.jwt &&
       {{- end }}
       bin/apply-config-from-env.py conf/client.conf &&
-      /pulsar/bin/pulsar-client --url pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:6651 produce -m hello public/default/test
+      /pulsar/bin/pulsar-client --url pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651 produce -m hello public/default/test
     volumeMounts:
       - name: certs
         mountPath: /pulsar/certs

--- a/helm-chart-sources/pulsar/templates/tests/tls-proxy.yaml
+++ b/helm-chart-sources/pulsar/templates/tests/tls-proxy.yaml
@@ -30,7 +30,7 @@ spec:
     image: "{{ .Values.image.bastion.repository }}:{{ .Values.image.bastion.tag }}"
     imagePullPolicy: {{ .Values.image.bastion.pullPolicy }}
     command: ["/pulsar/bin/pulsar-admin"]
-    args: ["--admin-url", "https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443", "tenants", "list"]
+    args: ["--admin-url", "https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443", "tenants", "list"]
   # Do not restart containers after they exit
   restartPolicy: Never
 ---
@@ -64,7 +64,7 @@ spec:
       cat /pulsar/token-superuser/superuser.jwt | tr -d '\n' > /pulsar/token-superuser-stripped.jwt &&
       {{- end }}
       bin/apply-config-from-env.py conf/client.conf &&
-      /pulsar/bin/pulsar-client --url pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651 produce -m hello public/default/test
+      /pulsar/bin/pulsar-client --url pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651 produce -m hello public/default/test
     volumeMounts:
       - name: certs
         mountPath: /pulsar/certs

--- a/helm-chart-sources/pulsar/templates/utils/_helpers.tpl
+++ b/helm-chart-sources/pulsar/templates/utils/_helpers.tpl
@@ -95,6 +95,13 @@ Create chart name and version as used by the chart label.
 {{- range $i, $e := until (.Values.zookeepernp.replicaCount | int) -}},{{ template "pulsar.fullname" $global }}-{{ $global.Values.zookeepernp.component }}-{{ printf "%d" $i }}.{{ template "pulsar.fullname" $global }}-{{ $global.Values.zookeepernp.component }}{{ end }}
 {{- end -}}
 
+{{/*
+Create the DNS suffix for Pulsar Services.
+*/}}
+{{- define "pulsar.serviceDnsSuffix" -}}
+{{- printf "%s.svc.%s" .Release.Namespace .Values.kubernetesClusterDomain  -}}
+{{- end -}}
+
 {{- define "pulsar.bkConnectString" -}}
 {{- $global := . -}}
 {{- range $i, $e := until (.Values.bookkeeper.replicaCount | int) -}}{{ if ne $i 0 }},{{ end }}bk://{{ template "pulsar.fullname" $global }}-{{ $global.Values.bookkeeper.component }}-{{ printf "%d" $i }}.{{ template "pulsar.fullname" $global }}-{{ $global.Values.bookkeeper.component }}:4181{{ end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
@@ -95,17 +95,17 @@ spec:
             bin/pulsar initialize-cluster-metadata \
               --cluster {{ template "pulsar.fullname" . }} \
               {{- if .Values.tls.zookeeper.enabled }}
-              --zookeeper {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281 \
-              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2281 \
+              --zookeeper {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281 \
+              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281 \
               {{- else }}
-              --zookeeper {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181 \
-              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca:2181 \
+              --zookeeper {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181 \
+              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181 \
               {{- end }}
               {{- if .Values.enableTls }}
-              --web-service-url-tls https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}:8443/ \
-              --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}:6651/ \
+              --web-service-url-tls https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443/ \
+              --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651/ \
               {{- end }}
-              --web-service-url http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}:8080/ \
-              --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}:6650/;
+              --web-service-url http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080/ \
+              --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/;
       restartPolicy: OnFailure
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
@@ -95,17 +95,17 @@ spec:
             bin/pulsar initialize-cluster-metadata \
               --cluster {{ template "pulsar.fullname" . }} \
               {{- if .Values.tls.zookeeper.enabled }}
-              --zookeeper {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281 \
-              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2281 \
+              --zookeeper {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281 \
+              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281 \
               {{- else }}
-              --zookeeper {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181 \
-              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ .Release.Namespace }}.svc.cluster.local:2181 \
+              --zookeeper {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181 \
+              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181 \
               {{- end }}
               {{- if .Values.enableTls }}
-              --web-service-url-tls https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:8443/ \
-              --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ .Release.Namespace }}.svc.cluster.local:6651/ \
+              --web-service-url-tls https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443/ \
+              --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6651/ \
               {{- end }}
-              --web-service-url http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:8080/ \
-              --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Release.Namespace }}.svc.cluster.local:6650/;
+              --web-service-url http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080/ \
+              --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650/;
       restartPolicy: OnFailure
 {{- end }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -24,6 +24,10 @@ fullnameOverride: pulsar
 # DNS name for loadbalancer
 dnsName: pulsar.example.com
 
+# The domain name for your kubernetes cluster. This domain is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records-1
+# and is used to fully qualify service names when configuring Pulsar.
+kubernetesClusterDomain: "cluster.local"
+
 # RBAC resource configuration
 rbac:
   # create ClusterRole/Role and ClusterRoleBinding/RoleBinding resources


### PR DESCRIPTION
Fixes: #184.

Hostname verification relies on the initial DNS named targeted. In order to support stricter requirements with DNS hostnames, we'll default to using the fully qualified service names when configuring Pulsar components.

Note: because the DNS names are part of the cluster initialization, you'll need to create a new cluster to take advantage of this feature or you'll need to run the admin command to update the cluster: `bin/pulsar-admin clusters update ...`.