### PR TITLE
Configure core Pulsar components to use ndots 4

### DIFF
--- a/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-deployment.yaml
@@ -50,6 +50,8 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/autorecovery/autorecovery-configmap.yaml") . | sha256sum }}
       {{- end }}
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/bastion/bastion-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion/bastion-deployment.yaml
@@ -50,6 +50,8 @@ spec:
 {{ toYaml .Values.bastion.annotations | indent 8 }}
       {{- end }}
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -51,6 +51,8 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/bookkeeper/bookkeeper-configmap.yaml") . | sha256sum }}
       {{- end }}
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
@@ -52,6 +52,8 @@ spec:
       {{- end }}
 {{ toYaml .Values.broker.annotations | indent 8 }}
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
@@ -49,6 +49,8 @@ spec:
       {{- end }}
 {{ toYaml .Values.brokerSts.annotations | indent 8 }}
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
       {{- end }}
 {{ toYaml .Values.function.annotations | indent 8 }}
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -52,6 +52,8 @@ spec:
       {{- end }}
 {{ toYaml .Values.proxy.annotations | indent 8 }}
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
@@ -48,6 +48,8 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/pulsar-heartbeat/pulsar-heartbeat-configmap.yaml") . | sha256sum }}
 {{ toYaml .Values.pulsarHeartbeat.annotations | indent 8 }}
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/helm-chart-sources/pulsar/templates/pulsarSql/deployment-coordinator.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/deployment-coordinator.yaml
@@ -39,6 +39,8 @@ spec:
         release: {{ .Release.Name }}
         component: coordinator
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.pulsarSQL.image.securityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.pulsarSQL.image.securityContext.runAsUser }}

--- a/helm-chart-sources/pulsar/templates/pulsarSql/deployment-worker.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsarSql/deployment-worker.yaml
@@ -41,6 +41,8 @@ spec:
         release: {{ .Release.Name }}
         component: worker
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.pulsarSQL.image.securityContext.enabled }}
       securityContext:
         runAsUser: {{ .Values.pulsarSQL.image.securityContext.runAsUser }}

--- a/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper-nonpersist/zookeepernp-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
       {{- end }}
 {{ toYaml .Values.zookeepernp.annotations | indent 8 }}
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
@@ -31,6 +31,8 @@ metadata:
 spec:
   template:
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.zookeeper.nodeAffinity }}
       affinity:
         nodeAffinity:

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -51,6 +51,8 @@ spec:
       {{- end }}
 {{ toYaml .Values.zookeeper.annotations | indent 8 }}
     spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
       {{- if .Values.priorityClass.enabled }}
       priorityClassName: pulsar-priority
       {{- end }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -28,6 +28,15 @@ dnsName: pulsar.example.com
 # and is used to fully qualify service names when configuring Pulsar.
 kubernetesClusterDomain: "cluster.local"
 
+# The DNS Config to apply to all pod specs. It is documented here: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config.
+# Note that because we use fully qualified service names for intra cluster networking with Pulsar components, we set
+# the ndots value to 4 (the default is 5). This prevents 3 DNS lookups for the fully qualified service names that would
+# be guaranteed to result in NXDOMAIN.
+dnsConfig:
+  options:
+    - name: ndots
+      value: "4"
+
 # RBAC resource configuration
 rbac:
   # create ClusterRole/Role and ClusterRoleBinding/RoleBinding resources


### PR DESCRIPTION
With our recent transition to using fully qualified service names, we need to make the ndots default to 4. Otherwise, we'll see small degradation on the DNS lookup performance. Since the Pulsar protocol relies on multiple DNS lookups when initiating connections to the proxy and the broker, I view this as an important optimization. This should not break any existing deployments.

I verified the contents of this change using minikube and tailing the coredns pod logs. I could clearly see before and after the changes that the configuration properly affects DNS lookups.

See this kubernetes documentation for more info: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service. Also, you can see this blog post for details on the performance impact: https://pracucci.com/kubernetes-dns-resolution-ndots-options-and-why-it-may-affect-application-performances.html