### PR TITLE
Improve self signed root CA cert secret configuration

### DIFF
--- a/examples/dev-values-tls-all-components.yaml
+++ b/examples/dev-values-tls-all-components.yaml
@@ -142,11 +142,11 @@ tls:
         algorithm: "ECDSA"
         size: 256
   ssCaCert:
+    tlsSecretName: "pulsar-ss-ca"
     certSpec:
       privateKey:
         algorithm: "ECDSA"
         size: 256
-  rootCaSecretName: "pulsar-ss-ca"
 
 # The current function worker code only uses TLS connections to brokers when authentication is enabled, so enable it here.
 enableTokenAuth: true

--- a/helm-chart-sources/pulsar/templates/bastion/bastion-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion/bastion-deployment.yaml
@@ -91,7 +91,7 @@ spec:
         {{- if .Values.enableTls }}
         - name: certs
           secret:
-            secretName: {{ .Values.tls.rootCaSecretName | default .Values.tlsSecretName | quote }}
+            secretName: {{ .Values.tls.ssCaCert.tlsSecretName | default (.Values.tls.rootCaSecretName | default .Values.tlsSecretName) | quote }}
             items:
               - key: ca.crt
                 path: ca.crt

--- a/helm-chart-sources/pulsar/templates/cert-manager/self-signed-cert-per-component.yaml
+++ b/helm-chart-sources/pulsar/templates/cert-manager/self-signed-cert-per-component.yaml
@@ -36,7 +36,7 @@ spec:
   privateKey:
 {{ toYaml .Values.tls.ssCaCert.certSpec.privateKey | indent 4 }}
   {{- end }}
-  secretName: "{{ template "pulsar.fullname" . }}-ss-ca"
+  secretName: {{ required "Must set .Values.tls.ssCaCert.tlsSecretName to create the root CA Cert" .Values.tls.ssCaCert.tlsSecretName }}
   commonName: "{{ template "pulsar.serviceDnsSuffix" . }}"
   usages:
     - server auth
@@ -52,7 +52,7 @@ metadata:
   name: "{{ template "pulsar.fullname" . }}-ca-issuer"
 spec:
   ca:
-    secretName: {{ template "pulsar.fullname" . }}-ss-ca
+    secretName: {{ required "Must set .Values.tls.ssCaCert.tlsSecretName to create the CA issuer" .Values.tls.ssCaCert.tlsSecretName }}
 ---
 {{- if .Values.tls.broker.createCertificates }}
 # Self-signed certificate for broker TLS

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
@@ -64,7 +64,7 @@ spec:
         {{- if .Values.enableTls }}
         - name: certs
           secret:
-            secretName: {{ .Values.tls.rootCaSecretName | default .Values.tlsSecretName | quote }}
+            secretName: {{ .Values.tls.ssCaCert.tlsSecretName | default (.Values.tls.rootCaSecretName | default .Values.tlsSecretName) | quote }}
             items:
               - key: ca.crt
                 path: ca.crt

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -245,15 +245,18 @@ tls:
       # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
       privateKey: {}
 
-  # Configuration for the CA Certificate. Only applied when using Cert Manager's self-signed certs per component.
+  # Configuration for the self-signed root CA Certificate. (All Pulsar components are assumed to share the same root CA.)
   ssCaCert:
+    # If set, supersedes the root "tlsSecretName" config. Note, this secret is used to configure TLS verification for
+    # components like the Bastion and the Pulsar HeartBeat.
+    tlsSecretName: ""
+    # Only applied when using Cert Manager's self-signed certs per component.
     certSpec:
       # Spec defined here: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
       # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
       privateKey: {}
 
-  # If using self-signed certs, it's essential to mount the root CA for TLS verification. If this value is specified,
-  # the chart will mount this secret's item named ca.crt to /pulsar/certs/ca.crt.
+  # Deprecated. Use tls.ssCaCert.tlsSecretName.
   rootCaSecretName: ""
 
 # secrets:


### PR DESCRIPTION
Fixes #190.

In order to better align with the rest of the configuration in the `.Values.tls` section, this PR replaces `rootCaSecretName` with `ssCaCert.tlsSecretName`. With this change, all TLS secret names are configured in the same way.