### PR TITLE
Set the advertisedAddress to pod IP when TLS isn't enabled

### DIFF
--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
@@ -280,6 +280,16 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}"
         env:
+        {{- if not .Values.enableTls }}
+        {{- /* 
+        advertisedAddress is set to podIP when TLS isn't enabled.
+        Using the podIP is not compatible with TLS hostname verification
+         */}}
+        - name: advertisedAddress
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- end }}
         {{- if .Values.broker.kafkaOnPulsarEnabled }}
         - name: PULSAR_PREFIX_kafkaAdvertisedListeners
           value: "PLAINTEXT://$(advertisedAddress):9092"


### PR DESCRIPTION
- DNS resolution causes an extra hop for Pulsar topic lookups
- DNS resolution fails with current settings until the broker's readiness probe succeeds. Pulsar might already return the hostname of a specific broker to a client, but the client cannot resolve the DNS name since the broker's readiness probe hasn't passed. This causes some extra delays when connecting to topics after a load balancing event.