### PR TITLE
Use dnsConfig single-request-reopen to address DNS intermittent delays of 5s

### DIFF
--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -36,6 +36,8 @@ dnsConfig:
   options:
     - name: ndots
       value: "4"
+    # workaround DNS intermittent delays of 5s, https://github.com/kubernetes/kubernetes/issues/56903
+    - name: single-request-reopen 
 
 # RBAC resource configuration
 rbac:


### PR DESCRIPTION
- see https://github.com/kubernetes/kubernetes/issues/56903 and https://github.com/Azure/AKS/issues/667#issuecomment-425821085