### PR TITLE
Add yamllint to CI Linting step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,11 @@ jobs:
     steps:
       - checkout
       - run:
-          command: ct lint --config tests/ct.yaml
+          # Helm lint doesn't prevent duplicate keys in yaml. However, this can lead to undesired behavior, so we store_test_results:
+          # for it using yamllint.
+          command: |
+            ct lint --all --config tests/ct.yaml
+            .circleci/yamllint-examples.sh
 
   install-charts:
     parameters:

--- a/.circleci/yamllint-examples.sh
+++ b/.circleci/yamllint-examples.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+mkdir -p yamllint/examples/
+rm -f yamllint/examples/*.yaml
+
+for FILE in examples/*.yaml; do
+  helm template pulsar-test -f $FILE helm-chart-sources/pulsar > yamllint/$FILE
+done
+
+# Lint all files in output directory
+yamllint yamllint/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Chart.lock
 .idea
 *.iml
 
+yamllint/

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,13 +1,12 @@
+# See https://yamllint.readthedocs.io for details.
+
 rules:
   braces: enable
   brackets: disable
   colons: disable
   commas: enable
-  comments:
-    level: warning
-    require-starting-space: false
-  comments-indentation:
-    level: warning
+  comments: disable
+  comments-indentation: disable
   document-end: disable
   document-start:
     level: warning

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,27 @@
+rules:
+  braces: enable
+  brackets: disable
+  colons: disable
+  commas: enable
+  comments:
+    level: warning
+    require-starting-space: false
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start:
+    level: warning
+  empty-lines: disable
+  empty-values: disable
+  hyphens: enable
+  indentation: disable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: disable
+  truthy:
+    level: warning

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -106,8 +106,6 @@ data:
   {{- if .Values.extra.function }}
   {{- if or .Values.tls.function.enabled .Values.tls.proxy.enableTlsWithBroker }}
   functionWorkerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:6751"
-  {{- else }}
-  functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:6750"
   {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
We recently encountered a situation where duplicate keys in a yaml manifest resulted in errors (#206). This new test will use `yamllint` to ensure that all of our `examples/` files and our default values file result in well formed yaml manifests.