### PR TITLE
Mm/fix/avoid hb bastion from mounting k8s certs secrets 204

### DIFF
--- a/helm-chart-sources/pulsar/templates/bastion/bastion-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion/bastion-configmap.yaml
@@ -36,7 +36,7 @@ data:
   # If proxy is deployed, use that for web service URL to
   # properly forward command to broker or function worker
   {{- if .Values.enableTls }}
-  tlsEnableHostnameVerification: "true"
+  tlsEnableHostnameVerification: "{{ .Values.tls.bastion.enableHostnameVerification }}"
     {{- if or .Values.secrets .Values.createCertificates.selfSigned.enabled .Values.createCertificates.selfSignedPerComponent.enabled }}
   tlsTrustCertsFilePath: "/pulsar/certs/ca.crt"
     {{- else }}

--- a/helm-chart-sources/pulsar/templates/bastion/bastion-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/bastion/bastion-deployment.yaml
@@ -88,7 +88,9 @@ spec:
           secret:
             secretName: token-superuser
         {{- end }}
-        {{- if .Values.enableTls }}
+        # index is workaround to not being able to refer to helm variables containing a dash
+        # find more: https://stackoverflow.com/questions/63853679/helm-templating-doesnt-let-me-use-dash-in-names#answer-63863410
+        {{- if and .Values.enableTls (not (index .Values "cert-manager").enabled) }}
         - name: certs
           secret:
             secretName: {{ .Values.tls.ssCaCert.tlsSecretName | default (.Values.tls.rootCaSecretName | default .Values.tlsSecretName) | quote }}
@@ -109,7 +111,7 @@ spec:
         - name: burnell
           containerPort: 8964
         volumeMounts:
-          {{- if .Values.enableTls }}
+          {{- if and .Values.enableTls (not (index .Values "cert-manager").enabled) }}
           - name: certs
             readOnly: true
             mountPath: /pulsar/certs
@@ -155,7 +157,7 @@ spec:
             name: token-superuser
             readOnly: true
           {{- end }}
-          {{- if .Values.enableTls }}
+          {{- if and .Values.enableTls (not (index .Values "cert-manager").enabled) }}
           - name: certs
             readOnly: true
             mountPath: /pulsar/certs

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -120,7 +120,6 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bookkeeper.gracePeriod }}
       initContainers:
-      {{- if .Values.enableWaitContainers }}
       # This init container will wait for zookeeper to be ready before
       # deploying the bookies
       - name: wait-zookeeper-ready
@@ -132,7 +131,6 @@ spec:
             until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} ls /admin/clusters | grep "^\[.*{{ template "pulsar.fullname" . }}.*\]"; do
               sleep 3;
             done;
-      {{- end }}
       # This initContainer will make sure that the bookkeeper
       # metadata is in zookeeper
       - name: pulsar-bookkeeper-metaformat

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -97,21 +97,24 @@ spec:
             topologyKey: "kubernetes.io/hostname"
           {{- end }}
           {{- if .Values.antiAffinity.zone.enabled }}
-          - labelSelector:
-              matchExpressions:
-              - key: "app"
-                operator: In
-                values:
-                - "{{ template "pulsar.name" . }}"
-              - key: "release"
-                operator: In
-                values:
-                - {{ .Release.Name }}
-              - key: "component"
-                operator: In
-                values:
-                - {{ .Values.bookkeeper.component }}
-            topologyKey: failure-domain.beta.kubernetes.io/zone
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              labelSelector:
+                matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                  - "{{ template "pulsar.name" . }}"
+                - key: "release"
+                  operator: In
+                  values:
+                  - {{ .Release.Name }}
+                - key: "component"
+                  operator: In
+                  values:
+                  - {{ .Values.bookkeeper.component }}
           {{- end }}
         {{- end }}
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -97,24 +97,21 @@ spec:
             topologyKey: "kubernetes.io/hostname"
           {{- end }}
           {{- if .Values.antiAffinity.zone.enabled }}
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              topologyKey: failure-domain.beta.kubernetes.io/zone
-              labelSelector:
-                matchExpressions:
-                - key: "app"
-                  operator: In
-                  values:
-                  - "{{ template "pulsar.name" . }}"
-                - key: "release"
-                  operator: In
-                  values:
-                  - {{ .Release.Name }}
-                - key: "component"
-                  operator: In
-                  values:
-                  - {{ .Values.bookkeeper.component }}
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "pulsar.name" . }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.bookkeeper.component }}
+            topologyKey: failure-domain.beta.kubernetes.io/zone
           {{- end }}
         {{- end }}
       {{- end }}

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -120,6 +120,7 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bookkeeper.gracePeriod }}
       initContainers:
+      {{- if .Values.enableWaitContainers }}
       # This init container will wait for zookeeper to be ready before
       # deploying the bookies
       - name: wait-zookeeper-ready
@@ -131,6 +132,7 @@ spec:
             until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} ls /admin/clusters | grep "^\[.*{{ template "pulsar.fullname" . }}.*\]"; do
               sleep 3;
             done;
+      {{- end }}
       # This initContainer will make sure that the bookkeeper
       # metadata is in zookeeper
       - name: pulsar-bookkeeper-metaformat

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
@@ -61,7 +61,9 @@ spec:
         - name: config-volume
           configMap:
             name: "{{ include "pulsar.fullname" . }}-{{ .Values.pulsarHeartbeat.component }}-config"
-        {{- if .Values.enableTls }}
+        # index is workaround to not being able to refer to helm variables containing a dash
+        # find more: https://stackoverflow.com/questions/63853679/helm-templating-doesnt-let-me-use-dash-in-names#answer-63863410
+        {{- if and .Values.enableTls (not (index .Values "cert-manager").enabled) }}
         - name: certs
           secret:
             secretName: {{ .Values.tls.ssCaCert.tlsSecretName | default (.Values.tls.rootCaSecretName | default .Values.tlsSecretName) | quote }}
@@ -75,7 +77,7 @@ spec:
       - name: wait-bookkeeper-ready
         image: "{{ .Values.image.broker.repository }}:{{ .Values.image.broker.tag }}"
         imagePullPolicy: {{ .Values.image.broker.pullPolicy }}
-        {{- if .Values.enableTls }}
+                {{- if and .Values.enableTls (not (index .Values "cert-manager").enabled) }}
         volumeMounts:
         - name: certs
           readOnly: true
@@ -84,18 +86,21 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
+            until curl 
             {{- if .Values.enableTls }}
-            until \
-            CA_CERT=/pulsar/certs/ca.crt curl --connect-timeout 5  --cacert ${CA_CERT} \
+            https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443 --connect-timeout 5
             {{- if not .Values.tls.pulsarHeartbeat.enableHostnameVerification }}
-            --insecure \
+            --insecure 
             {{- end }}
-            https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443
-            ; do
+            {{- if (index .Values "cert-manager").enabled }}
+            --cacert "{{ .Values.tlsCaPath }}/{{ .Values.tlsCaCert }}";
+            {{ else }}
+            --cacert /pulsar/certs/ca.crt;
+            {{- end }}
             {{- else }}
-            until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do
-            {{- end }}
-              sleep 3;
+            http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080 --connect-timeout 5;
+            {{- end }} 
+            do sleep 3;
             done;
       {{- end }}
       containers:
@@ -121,7 +126,7 @@ spec:
           volumeMounts:
           - name: config-volume
             mountPath: /config
-          {{- if .Values.enableTls }}
+            {{- if and .Values.enableTls (not (index .Values "cert-manager").enabled) }}
           - name: certs
             readOnly: true
             mountPath: /pulsar/certs

--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-deployment.yaml
@@ -85,7 +85,13 @@ spec:
         args:
           - >-
             {{- if .Values.enableTls }}
-            until curl --connect-timeout 5 --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
+            until \
+            CA_CERT=/pulsar/certs/ca.crt curl --connect-timeout 5  --cacert ${CA_CERT} \
+            {{- if not .Values.tls.pulsarHeartbeat.enableHostnameVerification }}
+            --insecure \
+            {{- end }}
+            https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443
+            ; do
             {{- else }}
             until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do
             {{- end }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -245,6 +245,8 @@ tls:
   bastion:
       enableHostnameVerification: true
       
+  pulsarHeartbeat:
+      enableHostnameVerification: true
 
   # Configuration for the self-signed root CA Certificate. (All Pulsar components are assumed to share the same root CA.)
   ssCaCert:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -242,6 +242,9 @@ tls:
       # Spec defined here: https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey
       # Can be used to override the default algorithm that Cert-Manager uses when signing keys.
       privateKey: {}
+  bastion:
+      enableHostnameVerification: true
+      
 
   # Configuration for the self-signed root CA Certificate. (All Pulsar components are assumed to share the same root CA.)
   ssCaCert:


### PR DESCRIPTION
Addresses #204. 

This solution prevents the k8s secret containing the TLS certificates from being mounted, if the cert-manager is enabled. It is based on the assumption that cert-manager enabled -> self-signed certificate mode is disabled.