### PR TITLE
Import official zookeeper dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,13 +295,6 @@ kube-prometheus-stack:
   enabled: true
 ```
 
-To enable the Grafana dashboards, use the following setting:
-
-```
-grafanaDashboards:
-  enabled: true
-```
-
 To enable the Kubernetes default rules, use the following setting:
 ```
 kube-prometheus-stack:
@@ -309,6 +302,20 @@ kube-prometheus-stack:
     create: true
 ```
 
+### Grafana Dashboards
+
+DataStax has several custom dashboards to help interpret Pulsar metrics. These custom dashboards are installed when the
+following is set in the values file:
+
+```
+grafanaDashboards:
+  enabled: true
+```
+
+Starting in Pulsar 2.8.0, the bundled Zookeeper process exports its own metrics instead of using the Pulsar metrics
+implementation. This results in new metrics names. As a result, we install two Grafana dashboards for Zookeeper. The
+first is a custom DataStax dashboard that works for versions before 2.8.0. The second is the official Zookeeper
+community Grafana dashboard: https://grafana.com/grafana/dashboards/10465.
 
 ## Example configurations
 

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1960,6 +1960,24 @@ kube-prometheus-stack:
     testFramework:
       enabled: false
     defaultDashboardsEnabled: true
+    dashboardProviders:
+      dashboardproviders.yaml:
+        apiVersion: 1
+        providers:
+        - name: 'default'
+          orgId: 1
+          folder: ''
+          type: file
+          disableDeletion: true
+          editable: false
+          options:
+            path: /var/lib/grafana/dashboards/default
+    dashboards:
+      default:
+        zookeeper:
+          gnetId: 10465
+          revision: 4
+          datasource: Prometheus
     # Configure to set a default admin password for Grafana
     adminPassword:
     service:


### PR DESCRIPTION
## Motivation

Starting with Pulsar 2.8.0, Zookeeper added prometheus metrics, and as a result, metrics names changed. This PR imports the official Zookeeper dashboard from grafana.com.

## Backwards Compatibility

In order to maintain compatibility with deployments less than 2.8.0, I am keeping the old zookeeper dashboard.