### PR TITLE
Fix integration tests: run test container as UID 1000

### DIFF
--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -76,11 +76,6 @@ create_kind_cluster() {
 
 
 install_charts() {
-    docker_exec ls -al / /workdir
-    docker_exec pwd
-    docker_exec id
-    docker_exec helm version --short
-    docker_exec git rev-parse --is-inside-work-tree
     docker_exec ct install --debug --config tests/ct.yaml
     echo
 }

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -73,6 +73,8 @@ create_kind_cluster() {
 
 
 install_charts() {
+    docker_exec ls / /worktree
+    docker_exec pwd
     docker_exec ct install --debug --config tests/ct.yaml
     echo
 }

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -73,7 +73,7 @@ create_kind_cluster() {
 
 
 install_charts() {
-    docker_exec ls / /worktree
+    docker_exec ls / /workdir
     docker_exec pwd
     docker_exec ct install --debug --config tests/ct.yaml
     echo

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -75,6 +75,8 @@ create_kind_cluster() {
 install_charts() {
     docker_exec ls / /workdir
     docker_exec pwd
+    docker_exec helm version --short
+    docker_exec git rev-parse --is-inside-work-tree
     docker_exec ct install --debug --config tests/ct.yaml
     echo
 }

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -32,7 +32,7 @@ cleanup() {
 }
 
 docker_exec_user() {
-    docker exec --user "$1" --interactive ct "$@"
+    docker exec --user $1 --interactive ct "$@"
 }
 
 docker_exec_root() {

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -32,7 +32,7 @@ cleanup() {
 }
 
 docker_exec_user() {
-    docker exec --user $1 --interactive ct "$@"
+    docker exec --user "$1" --interactive ct "$@"
 }
 
 docker_exec_root() {

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -31,9 +31,16 @@ cleanup() {
     echo 'Done!'
 }
 
-# Set the user so that it properly owns the git repo
+docker_exec_user() {
+    docker exec --user $1 --interactive ct "$@"
+}
+
+docker_exec_root() {
+    docker_exec_user 0 "$@"
+}
+
 docker_exec() {
-    docker exec --user 1000 --interactive ct "$@"
+    docker_exec_user 1000 "$@"
 }
 
 create_kind_cluster() {
@@ -58,10 +65,10 @@ create_kind_cluster() {
     else
         kind export kubeconfig --name "$CLUSTER_NAME"
     fi
-    docker_exec mkdir -p /root/.kube
+    docker_exec_root mkdir -p /.kube
 
     echo "Copying kubeconfig $KUBECONFIG to container..."
-    docker cp "$KUBECONFIG" ct:/root/.kube/config
+    docker cp "$KUBECONFIG" ct:/.kube/config
 
     docker_exec kubectl cluster-info
     echo

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -17,6 +17,7 @@ run_ct_container() {
         docker run --rm --interactive --detach --network host --name ct \
             --volume "$(pwd):/workdir" \
             --workdir /workdir \
+            --user 1000 \
             "quay.io/helmpack/chart-testing:$CT_VERSION" \
             cat
         echo
@@ -30,8 +31,9 @@ cleanup() {
     echo 'Done!'
 }
 
+# Set the user so that it properly owns the git repo
 docker_exec() {
-    docker exec --interactive ct "$@"
+    docker exec --user 1000 --interactive ct "$@"
 }
 
 create_kind_cluster() {

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -31,16 +31,9 @@ cleanup() {
     echo 'Done!'
 }
 
-docker_exec_user() {
-    docker exec --user $1 --interactive ct "$@"
-}
-
-docker_exec_root() {
-    docker_exec_user 0 "$@"
-}
-
+# Set the user so that it properly owns the git repo
 docker_exec() {
-    docker_exec_user 1000 "$@"
+    docker exec --user 1000 --interactive ct "$@"
 }
 
 create_kind_cluster() {
@@ -65,10 +58,10 @@ create_kind_cluster() {
     else
         kind export kubeconfig --name "$CLUSTER_NAME"
     fi
-    docker_exec_root mkdir -p /.kube
+    docker_exec mkdir -p /root/.kube
 
     echo "Copying kubeconfig $KUBECONFIG to container..."
-    docker cp "$KUBECONFIG" ct:/.kube/config
+    docker cp "$KUBECONFIG" ct:/root/.kube/config
 
     docker_exec kubectl cluster-info
     echo

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -73,8 +73,9 @@ create_kind_cluster() {
 
 
 install_charts() {
-    docker_exec ls / /workdir
+    docker_exec ls -al / /workdir
     docker_exec pwd
+    docker_exec id
     docker_exec helm version --short
     docker_exec git rev-parse --is-inside-work-tree
     docker_exec ct install --debug --config tests/ct.yaml

--- a/tests/e2e-kind.sh
+++ b/tests/e2e-kind.sh
@@ -18,6 +18,7 @@ run_ct_container() {
             --volume "$(pwd):/workdir" \
             --workdir /workdir \
             --user 1000 \
+            --env HOME=/workdir \
             "quay.io/helmpack/chart-testing:$CT_VERSION" \
             cat
         echo
@@ -58,10 +59,10 @@ create_kind_cluster() {
     else
         kind export kubeconfig --name "$CLUSTER_NAME"
     fi
-    docker_exec mkdir -p /root/.kube
+    docker_exec mkdir -p /workdir/.kube
 
     echo "Copying kubeconfig $KUBECONFIG to container..."
-    docker cp "$KUBECONFIG" ct:/root/.kube/config
+    docker cp "$KUBECONFIG" ct:/workdir/.kube/config
 
     docker_exec kubectl cluster-info
     echo


### PR DESCRIPTION
## Motivation

Builds started failing recently with a message `Error: Error installing charts: Error identifying charts to process: Must be in a git repository`. Based on some quick searching, it looks like the root cause is related to a git version bump that simultaneously resolves CVE-2022-24765 and breaks our build. 

## Solution

I chose to use the same UID for both creating the git repo and modifying it. The checkout command uses UID 1000, so the ct docker image must also use that UID.

## Rejected Alternative

I could have followed git's advice:

```
fatal: unsafe repository ('/workdir' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /workdir
```

However, I opted to use the same UID since that also gets us a non-root test container.