### PR TITLE
Upgrade keycloak to 6.x

### DIFF
--- a/helm-chart-sources/pulsar/Chart.yaml
+++ b/helm-chart-sources/pulsar/Chart.yaml
@@ -34,6 +34,6 @@ dependencies:
   repository: https://charts.jetstack.io
   condition: cert-manager.enabled
 - name: keycloak
-  version: 5.0.1
+  version: 5.2.8
   repository: https://charts.bitnami.com/bitnami
   condition: keycloak.enabled

--- a/helm-chart-sources/pulsar/Chart.yaml
+++ b/helm-chart-sources/pulsar/Chart.yaml
@@ -34,6 +34,6 @@ dependencies:
   repository: https://charts.jetstack.io
   condition: cert-manager.enabled
 - name: keycloak
-  version: 5.2.8
+  version: 9.2.1
   repository: https://charts.bitnami.com/bitnami
   condition: keycloak.enabled

--- a/helm-chart-sources/pulsar/Chart.yaml
+++ b/helm-chart-sources/pulsar/Chart.yaml
@@ -34,6 +34,6 @@ dependencies:
   repository: https://charts.jetstack.io
   condition: cert-manager.enabled
 - name: keycloak
-  version: 9.2.1
+  version: 6.2.5
   repository: https://charts.bitnami.com/bitnami
   condition: keycloak.enabled


### PR DESCRIPTION
Keycloak 5.x has been removed from the bitnami chart so it's not available anymore.

In short term the most easy upgrade is to 6.2.5.

In the future would be better to align to the latest one (9.x)

I'm running an [internal test](https://fallout.sjc.dsinternal.org/tests/ui/nicolo.boschi@datastax.com/cdc-multisink/28ee5aef-3617-4cdf-ac19-c1feda659711/artifacts) using 6.2.5