### PR TITLE
Bump all chart dependencies to latest versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ When using Cert-Manager to create your TLS certificates, you must first install 
 installed using the following command:
 
 ```shell
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.crds.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.crds.yaml
 ```
 
 If you don't, you will get error messages like this:
@@ -341,7 +341,7 @@ Note: With message/state persistence disabled, the cluster will not survive a re
 * dev-values-tls.yaml. Development environment with self-signed certificate created by cert-manager. You need to install the cert-manager CRDs before installing the Helm chart. The chart will install the cert-manager application.
 
 ```
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.crds.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.crds.yaml
 helm install pulsar -f dev-values-tls.yaml datastax-pulsar/pulsar
 ```
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ installed using the following command:
 kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.crds.yaml
 ```
 
+NOTE: if you're deploying a version of the chart before 3.0.0, you'll need to use version `v1.5.5` of the CRDs.
+
 If you don't, you will get error messages like this:
 
 > Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: [resource mapping not found for name: "pulsar-ca-certificate" namespace: "pulsar" from "": no matches for kind "Certificate" in version "cert-manager.io/v1"
@@ -345,6 +347,7 @@ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8
 helm install pulsar -f dev-values-tls.yaml datastax-pulsar/pulsar
 ```
 
+NOTE: if you're deploying a version of the chart before 3.0.0, you'll need to use version `v1.5.5` of the CRDs.
 
 ## Tiered Storage
 

--- a/aws-customer-docs.md
+++ b/aws-customer-docs.md
@@ -15,7 +15,7 @@ Reference: https://docs.cert-manager.io
 
 * Install the Cert-Manager CustomResourceDefinition resources
 ```
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.5/cert-manager.crds.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.8.0/cert-manager.crds.yaml
 ```
 
 * Create the namespace for Cert-Manager
@@ -38,7 +38,7 @@ helm repo update
 helm install \
   --name cert-manager \
   --namespace cert-manager \
-  --version v1.5.5 \
+  --version v1.8.0 \
   jetstack/cert-manager
 ```
 

--- a/helm-chart-sources/pulsar/Chart.yaml
+++ b/helm-chart-sources/pulsar/Chart.yaml
@@ -26,14 +26,14 @@ maintainers:
 version: 2.1.7
 dependencies:
 - name: kube-prometheus-stack
-  version: 12.x.x
+  version: 35.x.x
   repository: https://prometheus-community.github.io/helm-charts
   condition: kube-prometheus-stack.enabled
 - name: cert-manager
-  version: v1.5.x
+  version: v1.8.x
   repository: https://charts.jetstack.io
   condition: cert-manager.enabled
 - name: keycloak
-  version: 6.2.5
+  version: 9.x.x
   repository: https://charts.bitnami.com/bitnami
   condition: keycloak.enabled


### PR DESCRIPTION
In preparation for a 3.0.0 release, I propose we make a clean upgrade for all Pulsar dependencies. We'll need to perform additional testing and document an upgrade path before releasing this change. We'll also need to establish a way to keep up to date with the existing dependencies.