### PR TITLE
Add timeout for running "bin/pulsar initialize-cluster-metadata" command

### DIFF
--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
@@ -88,7 +88,7 @@ spec:
         resources:
 {{ toYaml .Values.zookeeperMetadata.resources | indent 10 }}
       {{- end }}
-        command: ["sh", "-c"]
+        command: ["timeout", "{{ .Values.zookeeperMetadata.initTimeout | default 60 }}", "sh", "-c"]
         args:
           - |
             {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -707,6 +707,8 @@ zookeepernp:
 ## metadata deployed
 zookeeperMetadata:
   component: zookeeper-metadata
+  ## timeout (in seconds) for running "bin/pulsar initialize-cluster-metadata" command
+  initTimeout: 60
 
 ## Pulsar: Bookkeeper cluster
 ## templates/bookkeeper-statefulset.yaml


### PR DESCRIPTION
- sometimes the Pulsar zookeeper metadata initialization job gets stuck and doesn't recover
  - add a 60 second default timeout

example error:
```
2022-06-13T11:33:42,814+0000 [main-SendThread(pulsar-luna-uswest1-staging-zookeeper-ca.pulsar.svc.cluster.local:2181)] WARN  org.apache.zookeeper.ClientCnxn - An exception was thrown while closing send thread for session 0x0.
java.net.ConnectException: Connection refused
	at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method) ~[?:?]
	at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:777) ~[?:?]
	at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:344) ~[org.apache.zookeeper-zookeeper-3.8.0.jar:3.8.0]
	at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1282) [org.apache.zookeeper-zookeeper-3.8.0.jar:3.8.0]
2022-06-13T11:33:42,921+0000 [main] INFO  org.apache.zookeeper.ZooKeeper - Session: 0x0 closed
2022-06-13T11:33:42,921+0000 [main-EventThread] INFO  org.apache.zookeeper.ClientCnxn - EventThread shut down for session: 0x0
Exception in thread "main" org.apache.pulsar.metadata.api.MetadataStoreException: org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.<init>(ZKMetadataStore.java:108)
	at org.apache.pulsar.metadata.impl.MetadataStoreFactoryImpl.newInstance(MetadataStoreFactoryImpl.java:56)
	at org.apache.pulsar.metadata.impl.MetadataStoreFactoryImpl.createExtended(MetadataStoreFactoryImpl.java:36)
	at org.apache.pulsar.metadata.api.extended.MetadataStoreExtended.create(MetadataStoreExtended.java:40)
	at org.apache.pulsar.PulsarClusterMetadataSetup.initMetadataStore(PulsarClusterMetadataSetup.java:380)
	at org.apache.pulsar.PulsarClusterMetadataSetup.main(PulsarClusterMetadataSetup.java:238)
Caused by: org.apache.zookeeper.KeeperException$ConnectionLossException: KeeperErrorCode = ConnectionLoss
	at org.apache.zookeeper.KeeperException.create(KeeperException.java:102)
	at org.apache.bookkeeper.zookeeper.ZooKeeperWatcherBase.waitForConnection(ZooKeeperWatcherBase.java:159)
	at org.apache.pulsar.metadata.impl.PulsarZooKeeperClient$Builder.build(PulsarZooKeeperClient.java:259)
	at org.apache.pulsar.metadata.impl.ZKMetadataStore.<init>(ZKMetadataStore.java:100)
	... 5 more
```

in Helm `--debug --wait` output:
```
ready.go:231: [debug] Job is not completed: pulsar/pulsar-luna-uswest1-staging-zookeeper-metadata
ready.go:231: [debug] Job is not completed: pulsar/pulsar-luna-uswest1-staging-zookeeper-metadata
ready.go:231: [debug] Job is not completed: pulsar/pulsar-luna-uswest1-staging-zookeeper-metadata
ready.go:231: [debug] Job is not completed: pulsar/pulsar-luna-uswest1-staging-zookeeper-metadata
ready.go:231: [debug] Job is not completed: pulsar/pulsar-luna-uswest1-staging-zookeeper-metadata
```