### PR TITLE
Support for Transaction Coordinator

### DIFF
--- a/examples/dev-values-transactions.yaml
+++ b/examples/dev-values-transactions.yaml
@@ -16,25 +16,16 @@
 #
 
 enableAntiAffinity: false
-enableTls: true
+enableTls: false
 enableTokenAuth: false
 restartOnConfigMapChange:
   enabled: true
 extra:
-  broker: false
-  brokerSts: true
   function: true
   burnell: true
   burnellLogCollector: true
   pulsarHeartbeat: true
   pulsarAdminConsole: true
-
-cert-manager:
-  enabled: true
-
-createCertificates:
-  selfSigned:
-    enabled: true
 
 zookeeper:
   replicaCount: 1
@@ -54,21 +45,21 @@ bookkeeper:
   configData:
     BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
-brokerSts:
+broker:
   component: broker
   replicaCount: 1
   ledger:
     defaultEnsembleSize: 1
     defaultAckQuorum: 1
     defaultWriteQuorum: 1
+  transactionCoordinator:
+    enabled: true
   resources:
     requests:
       memory: 600Mi
       cpu: 0.3
   configData:
     PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
-  transactionCoordinator:
-    enabled: true
 
 autoRecovery:
   resources:

--- a/examples/dev-values-transactions.yaml
+++ b/examples/dev-values-transactions.yaml
@@ -1,0 +1,111 @@
+#
+#  Copyright 2022 DataStax, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+enableAntiAffinity: false
+enableTls: false
+enableTokenAuth: false
+restartOnConfigMapChange:
+  enabled: true
+extra:
+  function: false
+  burnell: false
+  burnellLogCollector: false
+  pulsarHeartbeat: false
+  pulsarAdminConsole: false
+
+zookeeper:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "-Xms300m -Xmx300m -Djute.maxbuffer=10485760 -XX:+ExitOnOutOfMemoryError"
+
+bookkeeper:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  configData:
+    BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
+
+broker:
+  component: broker
+  replicaCount: 1
+  ledger:
+    defaultEnsembleSize: 1
+    defaultAckQuorum: 1
+    defaultWriteQuorum: 1
+  resources:
+    requests:
+      memory: 600Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
+    PULSAR_PREFIX_transactionCoordinatorEnabled: "true"
+  transactionCoordinator: 
+    enabled: true
+
+autoRecovery:
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 0.3
+
+function:
+  replicaCount: 1
+  functionReplicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
+
+proxy:
+  replicaCount: 1
+  resources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  wsResources:
+    requests:
+      memory: 512Mi
+      cpu: 0.3
+  configData:
+    PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=112m"
+  autoPortAssign:
+    enablePlainTextWithTLS: true
+  service:
+    autoPortAssign:
+      enabled: true
+
+grafanaDashboards:
+  enabled: true
+
+pulsarAdminConsole:
+  replicaCount: 1
+
+kube-prometheus-stack:
+  enabled: true
+  prometheusOperator:
+    enabled: true
+  grafana:
+    enabled: true
+    adminPassword: e9JYtk83*4#PM8

--- a/examples/dev-values-transactions.yaml
+++ b/examples/dev-values-transactions.yaml
@@ -16,16 +16,25 @@
 #
 
 enableAntiAffinity: false
-enableTls: false
+enableTls: true
 enableTokenAuth: false
 restartOnConfigMapChange:
   enabled: true
 extra:
-  function: false
-  burnell: false
-  burnellLogCollector: false
-  pulsarHeartbeat: false
-  pulsarAdminConsole: false
+  broker: false
+  brokerSts: true
+  function: true
+  burnell: true
+  burnellLogCollector: true
+  pulsarHeartbeat: true
+  pulsarAdminConsole: true
+
+cert-manager:
+  enabled: true
+
+createCertificates:
+  selfSigned:
+    enabled: true
 
 zookeeper:
   replicaCount: 1
@@ -45,7 +54,7 @@ bookkeeper:
   configData:
     BOOKIE_MEM: "-Xms312m -Xmx312m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
 
-broker:
+brokerSts:
   component: broker
   replicaCount: 1
   ledger:
@@ -58,7 +67,7 @@ broker:
       cpu: 0.3
   configData:
     PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
-  transactionCoordinator: 
+  transactionCoordinator:
     enabled: true
 
 autoRecovery:

--- a/examples/dev-values-transactions.yaml
+++ b/examples/dev-values-transactions.yaml
@@ -58,7 +58,6 @@ broker:
       cpu: 0.3
   configData:
     PULSAR_MEM: "-Xms400m -Xmx400m -XX:MaxDirectMemorySize=200m -XX:+ExitOnOutOfMemoryError"
-    PULSAR_PREFIX_transactionCoordinatorEnabled: "true"
   transactionCoordinator: 
     enabled: true
 

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -222,7 +222,6 @@ data:
 {{- if .Values.broker.transactionCoordinator.enabled }}
   PULSAR_PREFIX_transactionCoordinatorEnabled: "true"
 {{- end }}
-
 {{- range $key, $val := $.Values.broker.configData }}
   {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -218,6 +218,11 @@ data:
   {{- end }}
 {{- end }}
 {{- end }}
+  # Transactions
+{{- if .Values.broker.transactionCoordinator.enabled }}
+  PULSAR_PREFIX_transactionCoordinatorEnabled: "true"
+{{- end }}
+
 {{- range $key, $val := $.Values.broker.configData }}
   {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
@@ -50,7 +50,7 @@ spec:
       tolerations:
 {{ toYaml .Values.broker.tolerations | indent 8 }}
     {{- end }}
-     {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+     {{- if .Values.enableTls }}
       volumes:
       - name: certs
         secret:
@@ -86,7 +86,7 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerTransactionsMetadata.component }}"
         image: "{{ .Values.image.broker.repository }}:{{ .Values.image.broker.tag }}"
         imagePullPolicy: {{ .Values.image.broker.pullPolicy }}
-        {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+        {{- if and .Values.enableTls }}
         volumeMounts:
         - name: certs
           readOnly: true
@@ -101,7 +101,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - |
-            {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+            {{- if and .Values.enableTls }}
             /pulsar/tools/certconverter.sh &&
             {{- end }}
             bin/pulsar initialize-transaction-coordinator-metadata \

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
@@ -76,10 +76,7 @@ spec:
         args:
           - >-
             {{- if .Values.enableTls }}
-            until \
-            CA_CERT=/pulsar/certs/ca.crt curl --connect-timeout 5  --cacert ${CA_CERT} \
-            https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443
-            ; do
+            until curl --connect-timeout 5  --cacert pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
             {{- else }}
             until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do
             {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
@@ -75,7 +75,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            {{- if .Values.enableTls }}
+            {{- if and .Values.enableTls .Values.tls.broker.enabled }}
             until curl --connect-timeout 5  --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
             {{- else }}
             until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
@@ -86,7 +86,7 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerTransactionsMetadata.component }}"
         image: "{{ .Values.image.broker.repository }}:{{ .Values.image.broker.tag }}"
         imagePullPolicy: {{ .Values.image.broker.pullPolicy }}
-        {{- if and .Values.enableTls }}
+        {{- if .Values.enableTls }}
         volumeMounts:
         - name: certs
           readOnly: true
@@ -101,7 +101,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - |
-            {{- if and .Values.enableTls }}
+            {{- if .Values.enableTls }}
             /pulsar/tools/certconverter.sh &&
             {{- end }}
             bin/pulsar initialize-transaction-coordinator-metadata \

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
@@ -64,7 +64,7 @@ spec:
       - name: wait-broker-ready
         image: "{{ .Values.image.broker.repository }}:{{ .Values.image.broker.tag }}"
         imagePullPolicy: {{ .Values.image.broker.pullPolicy }}
-        {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+        {{- if .Values.enableTls }}
         volumeMounts:
         - name: certs
           readOnly: true
@@ -75,7 +75,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+            {{- if .Values.enableTls }}
             until curl --connect-timeout 5  --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
             {{- else }}
             until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
@@ -64,6 +64,14 @@ spec:
       - name: wait-broker-ready
         image: "{{ .Values.image.broker.repository }}:{{ .Values.image.broker.tag }}"
         imagePullPolicy: {{ .Values.image.broker.pullPolicy }}
+        {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+        volumeMounts:
+        - name: certs
+          readOnly: true
+          mountPath: /pulsar/certs
+        - name: certconverter
+          mountPath: /pulsar/tools
+        {{- end }}
         command: ["sh", "-c"]
         args:
           - >-

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
@@ -76,7 +76,7 @@ spec:
         args:
           - >-
             {{- if .Values.enableTls }}
-            until curl --connect-timeout 5  --cacert pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
+            until curl --connect-timeout 5  --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
             {{- else }}
             until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do
             {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
@@ -1,0 +1,113 @@
+#
+#  Copyright 2022 DataStax, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+{{- if .Values.extra.broker }}
+{{- if and .Values.broker.transactionCoordinator.enabled (or .Release.IsInstall .Values.initialize) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerTransactionsMetadata.component }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.brokerTransactionsMetadata.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+spec:
+  template:
+    spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- if .Values.broker.nodeAffinity }}
+      affinity:
+        nodeAffinity:
+{{ toYaml .Values.broker.nodeAffinity | indent 10 }}
+      {{- end }}
+    {{- if and (.Values.nodeSelector) (not .Values.broker.nodeSelector) }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.broker.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.broker.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.broker.tolerations }}
+      tolerations:
+{{ toYaml .Values.broker.tolerations | indent 8 }}
+    {{- end }}
+     {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+      volumes:
+      - name: certs
+        secret:
+          secretName: {{ .Values.tls.broker.tlsSecretName | default .Values.tlsSecretName | quote }}
+      - name: certconverter
+        configMap:
+          name: "{{ template "pulsar.fullname" . }}-certconverter-configmap"
+          defaultMode: 0755
+      {{- end }}
+      initContainers:
+      - name: wait-broker-ready
+        image: "{{ .Values.image.broker.repository }}:{{ .Values.image.broker.tag }}"
+        imagePullPolicy: {{ .Values.image.broker.pullPolicy }}
+        command: ["sh", "-c"]
+        args:
+          - >-
+            {{- if .Values.enableTls }}
+            until \
+            CA_CERT=/pulsar/certs/ca.crt curl --connect-timeout 5  --cacert ${CA_CERT} \
+            https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443
+            ; do
+            {{- else }}
+            until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do
+            {{- end }}
+              sleep 3;
+            done;
+      containers:
+      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerTransactionsMetadata.component }}"
+        image: "{{ .Values.image.broker.repository }}:{{ .Values.image.broker.tag }}"
+        imagePullPolicy: {{ .Values.image.broker.pullPolicy }}
+        {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+        volumeMounts:
+        - name: certs
+          readOnly: true
+          mountPath: /pulsar/certs
+        - name: certconverter
+          mountPath: /pulsar/tools
+        {{- end }}
+      {{- if .Values.brokerTransactionsMetadata.resources }}
+        resources:
+{{ toYaml .Values.brokerTransactionsMetadata.resources | indent 10 }}
+      {{- end }}
+        command: ["sh", "-c"]
+        args:
+          - |
+            {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+            /pulsar/tools/certconverter.sh &&
+            {{- end }}
+            bin/pulsar initialize-transaction-coordinator-metadata \
+              --cluster {{ template "pulsar.fullname" . }} \
+              {{- if .Values.tls.zookeeper.enabled }}
+              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281 \
+              {{- else }}
+              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181 \
+              {{- end }}
+              --initial-num-transaction-coordinators {{ .Values.broker.transactionCoordinator.initialCount }} \
+              ;
+      restartPolicy: OnFailure
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -223,6 +223,10 @@ data:
   {{- end }}
 {{- end }}
 {{- end }}
+  # Transactions
+{{- if .Values.brokerSts.transactionCoordinator.enabled }}
+  PULSAR_PREFIX_transactionCoordinatorEnabled: "true"
+{{- end }}
 {{- range $key, $val := $.Values.brokerSts.configData }}
   {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
@@ -77,10 +77,7 @@ spec:
         args:
           - >-
             {{- if .Values.enableTls }}
-            until \
-            CA_CERT=/pulsar/certs/ca.crt curl --connect-timeout 5  --cacert ${CA_CERT} \
-            https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443
-            ; do
+            until curl --connect-timeout 5 --cacert pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
             {{- else }}
             until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do
             {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
@@ -65,6 +65,14 @@ spec:
       - name: wait-broker-ready
         image: "{{ .Values.image.brokerSts.repository }}:{{ .Values.image.brokerSts.tag }}"
         imagePullPolicy: {{ .Values.image.brokerSts.pullPolicy }}
+        {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+        volumeMounts:
+        - name: certs
+          readOnly: true
+          mountPath: /pulsar/certs
+        - name: certconverter
+          mountPath: /pulsar/tools
+        {{- end }}
         command: ["sh", "-c"]
         args:
           - >-

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
@@ -77,7 +77,7 @@ spec:
         args:
           - >-
             {{- if .Values.enableTls }}
-            until curl --connect-timeout 5 --cacert pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
+            until curl --connect-timeout 5 --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
             {{- else }}
             until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do
             {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
@@ -1,0 +1,114 @@
+#
+#  Copyright 2022 DataStax, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+#
+
+{{- if .Values.extra.brokerSts }}
+{{- if and .Values.brokerSts.transactionCoordinator.enabled (or .Release.IsInstall .Values.initialize) }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerTransactionsMetadata.component }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.brokerTransactionsMetadata.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+spec:
+  template:
+    spec:
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+      {{- if .Values.brokerSts.nodeAffinity }}
+      affinity:
+        nodeAffinity:
+{{ toYaml .Values.brokerSts.nodeAffinity | indent 10 }}
+      {{- end }}
+    {{- if and (.Values.nodeSelector) (not .Values.brokerSts.nodeSelector) }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.brokerSts.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.brokerSts.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.brokerSts.tolerations }}
+      tolerations:
+{{ toYaml .Values.brokerSts.tolerations | indent 8 }}
+    {{- end }}
+     {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+      volumes:
+      - name: certs
+        secret:
+          secretName: {{ .Values.tls.broker.tlsSecretName | default .Values.tlsSecretName | quote }}
+      - name: certconverter
+        configMap:
+          name: "{{ template "pulsar.fullname" . }}-certconverter-configmap"
+          defaultMode: 0755
+      {{- end }}
+      initContainers:
+      - name: wait-broker-ready
+        image: "{{ .Values.image.brokerSts.repository }}:{{ .Values.image.brokerSts.tag }}"
+        imagePullPolicy: {{ .Values.image.brokerSts.pullPolicy }}
+        command: ["sh", "-c"]
+        args:
+          - >-
+            {{- if .Values.enableTls }}
+            until \
+            CA_CERT=/pulsar/certs/ca.crt curl --connect-timeout 5  --cacert ${CA_CERT} \
+            https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443
+            ; do
+            {{- else }}
+            until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do
+            {{- end }}
+              sleep 3;
+            done;
+      containers:
+      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerTransactionsMetadata.component }}"
+        image: "{{ .Values.image.brokerSts.repository }}:{{ .Values.image.brokerSts.tag }}"
+        imagePullPolicy: {{ .Values.image.brokerSts.pullPolicy }}
+        {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+        volumeMounts:
+        - name: certs
+          readOnly: true
+          mountPath: /pulsar/certs
+        - name: certconverter
+          mountPath: /pulsar/tools
+        {{- end }}
+      {{- if .Values.brokerTransactionsMetadata.resources }}
+        resources:
+{{ toYaml .Values.brokerTransactionsMetadata.resources | indent 10 }}
+      {{- end }}
+        command: ["sh", "-c"]
+        args:
+          - |
+            {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+            /pulsar/tools/certconverter.sh &&
+            {{- end }}
+            bin/pulsar initialize-transaction-coordinator-metadata \
+              --cluster {{ template "pulsar.fullname" . }} \
+              {{- if .Values.tls.zookeeper.enabled }}
+              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281 \
+              {{- else }}
+              --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181 \
+              {{- end }}
+              --initial-num-transaction-coordinators {{ .Values.brokerSts.transactionCoordinator.initialCount }} \
+              ;
+      restartPolicy: OnFailure
+{{- end }}
+{{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
@@ -65,7 +65,7 @@ spec:
       - name: wait-broker-ready
         image: "{{ .Values.image.brokerSts.repository }}:{{ .Values.image.brokerSts.tag }}"
         imagePullPolicy: {{ .Values.image.brokerSts.pullPolicy }}
-        {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+        {{- if .Values.enableTls }}
         volumeMounts:
         - name: certs
           readOnly: true
@@ -76,7 +76,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+            {{- if .Values.enableTls }}
             until curl --connect-timeout 5 --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
             {{- else }}
             until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
@@ -51,7 +51,7 @@ spec:
       tolerations:
 {{ toYaml .Values.brokerSts.tolerations | indent 8 }}
     {{- end }}
-     {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+     {{- if .Values.enableTls }}
       volumes:
       - name: certs
         secret:
@@ -87,7 +87,7 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerTransactionsMetadata.component }}"
         image: "{{ .Values.image.brokerSts.repository }}:{{ .Values.image.brokerSts.tag }}"
         imagePullPolicy: {{ .Values.image.brokerSts.pullPolicy }}
-        {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+        {{- if .Values.enableTls }}
         volumeMounts:
         - name: certs
           readOnly: true
@@ -102,7 +102,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - |
-            {{- if and .Values.enableTls .Values.tls.broker.enabled }}
+            {{- if .Values.enableTls }}
             /pulsar/tools/certconverter.sh &&
             {{- end }}
             bin/pulsar initialize-transaction-coordinator-metadata \

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
@@ -76,7 +76,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            {{- if .Values.enableTls }}
+            {{- if and .Values.enableTls .Values.tls.broker.enabled }}
             until curl --connect-timeout 5 --cacert /pulsar/certs/ca.crt https://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443; do
             {{- else }}
             until curl --connect-timeout 5 http://{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8080; do

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -889,7 +889,7 @@ broker:
   # See extra section above
   functionsWorkerEnabled: false
   webSocketServiceEnabled: false
-  transactionCoordinator: 
+  transactionCoordinator:
     enabled: false
     initialCount: 16
   probe:
@@ -1003,7 +1003,7 @@ brokerSts:
   # See extras section above
   functionsWorkerEnabled: false
   webSocketServiceEnabled: false
-  transactionCoordinator: 
+  transactionCoordinator:
     enabled: false
     initialCount: 16
   probe:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -407,32 +407,32 @@ image:
     # If not using tiered storage, you can use the smaller pulsar image for the broker
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.10_0.2
+    tag: 2.8.3_1.0.11
   brokerSts:
     # If not using tiered storage, you can use the smaller pulsar image for the broker
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.10_0.2
+    tag: 2.8.3_1.0.11
   function:
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.10_0.2
+    tag: 2.8.3_1.0.11
   zookeeper:
-    repository: datastax/lunastreaming-all
+    repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.10_0.2
+    tag: 2.8.3_1.0.11
   bookkeeper:
-    repository: datastax/lunastreaming-all
+    repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.10_0.2
+    tag: 2.8.3_1.0.11
   proxy:
-    repository: datastax/lunastreaming-all
+    repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.10_0.2
+    tag: 2.8.3_1.0.11
   bastion:
-    repository: datastax/lunastreaming-all
+    repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.10_0.2
+    tag: 2.8.3_1.0.11
   pulsarBeam:
     repository: kesque/pulsar-beam
     pullPolicy: IfNotPresent
@@ -447,7 +447,7 @@ image:
     tag: logcollector_latest
   pulsarSQL:
     repository: datastax/lunastreaming-all
-    tag: 2.10_0.2
+    tag: 2.8.3_1.0.11
     pullPolicy: IfNotPresent
   tardigrade:
     repository: storjlabs/gateway
@@ -1078,12 +1078,8 @@ brokerSts:
     usePolicy: true
     maxUnavailable: 1
 
-## Pulsar Zookeeper metadata. The metadata will be deployed as
-## soon as the last zookeeper node is reachable. The deployment
-## of other components that depends on zookeeper, such as the
-## bookkeeper nodes, broker nodes, etc. will only start to be
-## deployed when the zookeeper cluster is ready and with the
-## metadata deployed
+## Pulsar Transactions metadata. The metadata will be deployed as
+## soon as a broker pod is available.
 brokerTransactionsMetadata:
   component: broker-transactions-metadata
 

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1003,6 +1003,9 @@ brokerSts:
   # See extras section above
   functionsWorkerEnabled: false
   webSocketServiceEnabled: false
+  transactionCoordinator: 
+    enabled: false
+    initialCount: 16
   probe:
     enabled: true
     port: 8080

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -889,8 +889,12 @@ broker:
   # See extra section above
   functionsWorkerEnabled: false
   webSocketServiceEnabled: false
+  # Enable Transactions on the Pulsar cluster.
+  # It starts the transaction coordinator module inside the broker.
+  # It runs the Transaction coordinator metadata setup job.
   transactionCoordinator:
     enabled: false
+    # Count of partitions used for the transaction coordinator.
     initialCount: 16
   probe:
     enabled: true
@@ -1078,8 +1082,9 @@ brokerSts:
     usePolicy: true
     maxUnavailable: 1
 
-## Pulsar Transactions metadata. The metadata will be deployed as
-## soon as a broker pod is available.
+## Pulsar Transactions metadata setup. 
+## This is the job responsible to prepare the cluster for enabling transactions.
+## Job will start as soon as one broker pod is available.
 brokerTransactionsMetadata:
   component: broker-transactions-metadata
 

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1082,9 +1082,9 @@ brokerSts:
     usePolicy: true
     maxUnavailable: 1
 
-## Pulsar Transactions metadata setup. 
+## Pulsar Transactions metadata setup.
 ## This is the job responsible to prepare the cluster for enabling transactions.
-## Job will start as soon as one broker pod is available.
+## Job will start as soon as one broker pod is available.
 brokerTransactionsMetadata:
   component: broker-transactions-metadata
 

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -407,32 +407,32 @@ image:
     # If not using tiered storage, you can use the smaller pulsar image for the broker
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_0.2
   brokerSts:
     # If not using tiered storage, you can use the smaller pulsar image for the broker
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_0.2
   function:
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_0.2
   zookeeper:
-    repository: datastax/lunastreaming
+    repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_0.2
   bookkeeper:
-    repository: datastax/lunastreaming
+    repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_0.2
   proxy:
-    repository: datastax/lunastreaming
+    repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_0.2
   bastion:
-    repository: datastax/lunastreaming
+    repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_0.2
   pulsarBeam:
     repository: kesque/pulsar-beam
     pullPolicy: IfNotPresent
@@ -447,7 +447,7 @@ image:
     tag: logcollector_latest
   pulsarSQL:
     repository: datastax/lunastreaming-all
-    tag: 2.8.3_1.0.11
+    tag: 2.10_0.2
     pullPolicy: IfNotPresent
   tardigrade:
     repository: storjlabs/gateway
@@ -889,6 +889,9 @@ broker:
   # See extra section above
   functionsWorkerEnabled: false
   webSocketServiceEnabled: false
+  transactionCoordinator: 
+    enabled: false
+    initialCount: 16
   probe:
     enabled: true
     port: 8080
@@ -1071,6 +1074,15 @@ brokerSts:
   pdb:
     usePolicy: true
     maxUnavailable: 1
+
+## Pulsar Zookeeper metadata. The metadata will be deployed as
+## soon as the last zookeeper node is reachable. The deployment
+## of other components that depends on zookeeper, such as the
+## bookkeeper nodes, broker nodes, etc. will only start to be
+## deployed when the zookeeper cluster is ready and with the
+## metadata deployed
+brokerTransactionsMetadata:
+  component: broker-transactions-metadata
 
 function:
   component: function


### PR DESCRIPTION
- New Job that initialize metadata for transactions (create system namespace and topics)
- It depends on broker component and it waits a broker to be available
- The K8s job config (affinity, tolerations...) are coupled with the Broker
- There are two different jobs, one for broker deployment and one for the broker sts (they are the same except for the k8s configs)
- There's a new dictionary inside `broker` and `brokerSts`: ´transactionCoordinator´ with ´enabled: false´ and ´initialCount: 16´
- If you configure the broker to initialize the transactions metadata, also the parameter `transactionCoordinatorEnabled` will be set to true

Note: I haven't verified it with TLS for now