### PR TITLE
Support disabling Zookeeper client in Proxy

### DIFF
--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -42,6 +42,7 @@ data:
   brokerWebServiceURLTLS: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443"
   {{- end }}
   {{- end }}
+  {{- if .Values.proxy.zookeeperClientEnabled }}
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}
@@ -70,6 +71,7 @@ data:
     {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- end }}
     {{- end }}
+  {{- end }}
   {{- if .Values.extra.function }}
   functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:6750"
   {{- end }}
@@ -111,7 +113,7 @@ data:
 {{- end }}
 {{- if .Values.enableTokenAuth }}
   authenticationEnabled: "true"
-  authorizationEnabled: "true"
+  authorizationEnabled: "{{ .Values.proxy.authorizationEnabled }}"
   superUserRoles: "{{ .Values.superUserRoles }}"
   {{- if .Values.proxy.extraAuthProvider }}
   authenticationProviders: "{{ .Values.proxy.authenticationProviders }},{{ .Values.proxy.extraAuthProvider }}"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -42,6 +42,7 @@ data:
   serviceUrlTls: "https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:8443"
   {{- end }}
   {{- end }}
+  {{- if .Values.proxy.zookeeperClientEnabled }}
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281"
@@ -54,6 +55,7 @@ data:
     {{- else }}
     "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181"
     {{- end }}
+  {{- end }}
   clusterName: {{ template "pulsar.fullname" . }}
   webServicePort: "{{ .Values.proxy.wsProxyPort }}"
   {{- if .Values.enableTokenAuth }}
@@ -62,7 +64,7 @@ data:
   authenticationEnabled: "true"
   authenticationProviders: "{{ .Values.proxy.wsAuthenticationProviders }}"
   tokenPublicKey: "file:///pulsar/token-public-key/{{ .Values.tokenPublicKeyFile }}"
-  authorizationEnabled: "true"
+  authorizationEnabled: "{{ .Values.proxy.authorizationEnabled }}"
   superUserRoles: "{{ .Values.superUserRoles }}"
   {{- if .Values.keycloak.enabled }}
   PULSAR_PREFIX_openIDAllowedTokenIssuers: "{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ .Release.Namespace }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }},{{ template "pulsar.get.http.or.https" . }}{{ template "pulsar.keycloak.fullname" .}}.{{ template "pulsar.serviceDnsSuffix" . }}{{ template "pulsar.keycloak.issuer.port" .}}/auth/realms/{{ .Values.keycloak.realm }}"

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1272,6 +1272,11 @@ burnell: {}
 proxy:
   component: proxy
   replicaCount: 3
+  # when authorization is enabled, proxy will check authorization before proxying requests. zookeeperClientEnabled must be set to true
+  authorizationEnabled: true
+  # when disabled, proxy won't be configured to connect to zookeeper
+  zookeeperClientEnabled: true
+  # when false, broker address will be looked up in zookeeper
   disableZookeeperDiscovery: true
   # use "brokersts" instead of "broker" to identify the broker k8s component
   useStsBrokersForDiscovery: false


### PR DESCRIPTION
### Motivation

[Pulsar proxy documentation makes this recommendation](https://pulsar.apache.org/docs/next/administration-proxy#configure-the-proxy):
> In a production environment service discovery is not recommended.

> However, it is not secure to use service discovery. Because if the network ACL is open, when someone compromises a proxy, they have full access to ZooKeeper.

it also explains that you cannot use authorization when zookeeper client isn't configured in the proxy:

> Proxy authorization requires access to ZooKeeper, so if you use these broker URLs to connect to the brokers, you need to disable authorization at the Proxy level. Brokers still authorize requests after the proxy forwards them.

### Modifications

- add new values keys `.Values.proxy.zookeeperClientEnabled` and `.Values.proxy.authorizationEnabled` to allow disabling the zookeeper client in Proxy and for disabling authorization in the proxy. the default values are true for these settings.