### PR TITLE
Use lunastreaming-all for proxy and keycloak (temporary solution)

### DIFF
--- a/examples/dev-values-keycloak-auth-tls.yaml
+++ b/examples/dev-values-keycloak-auth-tls.yaml
@@ -15,6 +15,11 @@
 #
 #
 
+# Temporary solution for issue described in https://github.com/datastax/pulsar-helm-chart/issues/244
+image:
+  proxy:
+    repository: datastax/lunastreaming-all
+
 enableAntiAffinity: false
 enableTls: true
 #tls:

--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -15,6 +15,11 @@
 #
 #
 
+# Temporary solution for issue described in https://github.com/datastax/pulsar-helm-chart/issues/244
+image:
+  proxy:
+    repository: datastax/lunastreaming-all
+
 enableAntiAffinity: false
 # TLS is not included in this example. It is recommended to use TLS to ensure the authenticity and security of tokens.
 enableTls: false


### PR DESCRIPTION
Fixes: #244

This PR should be reverted when we have the jar in the non-all docker image.