### PR TITLE
Fix default topic name setting for heartbeat

### DIFF
--- a/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/pulsar-heartbeat/pulsar-heartbeat-configmap.yaml
@@ -89,7 +89,7 @@ data:
         {{- else }}
         pulsarUrl: "pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.serviceDnsSuffix" . }}:6650"
         {{- end }}
-        topicName: {{ .Values.pulsarHeartbeat.config.latencyTest.intervalSeconds | default "persistent://public/default/pubsub-latency-test" }}
+        topicName: {{ .Values.pulsarHeartbeat.config.latencyTest.topicName | default "persistent://public/default/pubsub-latency-test" }}
         payloadSizes: [15B]
         numberOfMessages: 1
         alertPolicy:


### PR DESCRIPTION
The current default is set to the latency interval, so the topic name is "60".