### PR TITLE
Rename "GC Pauses" to "GC Time" in Pulsar JVM dashboards

### DIFF
--- a/helm-chart-sources/pulsar/grafana-dashboards/jvm.json
+++ b/helm-chart-sources/pulsar/grafana-dashboards/jvm.json
@@ -454,7 +454,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "GC Pauses",
+      "title": "GC Time",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -939,7 +939,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "GC Pauses",
+      "title": "GC Time",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1424,7 +1424,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "GC Pauses",
+      "title": "GC Time",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1909,7 +1909,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "GC Pauses",
+      "title": "GC Time",
       "tooltip": {
         "shared": true,
         "sort": 0,


### PR DESCRIPTION
- source metric is not about GC pauses.
- the source metric is "jvm_gc_collection_seconds_sum" which is not the same as "GC pause"
- The metric is defined in Prometheus Java client
  - "Time spent in a given JVM garbage collector in seconds."
  - source code is https://github.com/prometheus/client_java/blob/e68daf23336eb5de7856df406eb1d497f51ad3be/simpleclient_hotspot/src/main/java/io/prometheus/client/hotspot/GarbageCollectorExports.java#L53
    - calls GarbageCollectorMXBean.getCollectionTime()
      - Javadoc https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/GarbageCollectorMXBean.html#getCollectionTime()
        "Returns the approximate accumulated collection elapsed time in milliseconds."
     - Stackoverflow Q&A: https://stackoverflow.com/a/44686539