### PR TITLE
upgrade external-dns container image

### DIFF
--- a/helm-chart-sources/pulsar/templates/dns/dns-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/dns/dns-deployment.yaml
@@ -60,7 +60,7 @@ spec:
       {{- end }}
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: k8s.gcr.io/external-dns/external-dns:v0.12.2
         {{- if .Values.dns.azureVolume }}
         volumeMounts:
           - mountPath: "/etc/kubernetes/"


### PR DESCRIPTION
The older image is no longer available, this updates to the current supported image.
https://github.com/kubernetes-sigs/external-dns