### PR TITLE
Upgrade Luna Streaming to 2.10 1.5

### DIFF
--- a/examples/dev-values-keycloak-auth-tls.yaml
+++ b/examples/dev-values-keycloak-auth-tls.yaml
@@ -15,11 +15,6 @@
 #
 #
 
-# Temporary solution for issue described in https://github.com/datastax/pulsar-helm-chart/issues/244
-image:
-  proxy:
-    repository: datastax/lunastreaming-all
-
 enableAntiAffinity: false
 enableTls: true
 #tls:

--- a/examples/dev-values-keycloak-auth.yaml
+++ b/examples/dev-values-keycloak-auth.yaml
@@ -15,11 +15,6 @@
 #
 #
 
-# Temporary solution for issue described in https://github.com/datastax/pulsar-helm-chart/issues/244
-image:
-  proxy:
-    repository: datastax/lunastreaming-all
-
 enableAntiAffinity: false
 # TLS is not included in this example. It is recommended to use TLS to ensure the authenticity and security of tokens.
 enableTls: false

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -411,32 +411,32 @@ image:
     # If not using tiered storage, you can use the smaller pulsar image for the broker
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_1.5
   brokerSts:
     # If not using tiered storage, you can use the smaller pulsar image for the broker
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_1.5
   function:
     repository: datastax/lunastreaming-all
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_1.5
   zookeeper:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_1.5
   bookkeeper:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_1.5
   proxy:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_1.5
   bastion:
     repository: datastax/lunastreaming
     pullPolicy: IfNotPresent
-    tag: 2.8.3_1.0.11
+    tag: 2.10_1.5
   pulsarBeam:
     repository: kesque/pulsar-beam
     pullPolicy: IfNotPresent
@@ -451,7 +451,7 @@ image:
     tag: logcollector_latest
   pulsarSQL:
     repository: datastax/lunastreaming-all
-    tag: 2.8.3_1.0.11
+    tag: 2.10_1.5
     pullPolicy: IfNotPresent
   tardigrade:
     repository: storjlabs/gateway


### PR DESCRIPTION
* Upgraded to 2.10 1.5
* Reverted https://github.com/datastax/pulsar-helm-chart/pull/245 since now the base distro contains the ` pulsar-openid-connect-plugin` jar