### PR TITLE
remove old nginx config

### DIFF
--- a/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/admin-console/pulsar-admin-console-deployment.yaml
@@ -97,12 +97,6 @@ spec:
             items:
             - key: local.json
               path: local.json
-        - name: nginxconf
-          configMap:
-            name: {{ template "pulsar.fullname" . }}-{{ .Values.pulsarAdminConsole.component }}-nginx
-            items:
-            - key: nginx.conf
-              path: nginx.conf
         {{- if .Values.enableTls }}
         - name: certs
           secret:


### PR DESCRIPTION
Nginx was removed in #227, but looks like this bit was missed.  The nginxconf volume currently references a non-existing configmap, so it should be removed.