### PR TITLE
use static page for broker liveness probe

### DIFF
--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -29,6 +29,7 @@ metadata:
     component: {{ .Values.broker.component }}
     cluster: {{ template "pulsar.fullname" . }}
 data:
+  statusFilePath: "/pulsar/status"
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
       {{- if .Values.extra.zookeepernp }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
@@ -220,9 +220,9 @@ spec:
           periodSeconds:  {{ .Values.broker.probe.period }}
           timeoutSeconds:  {{ .Values.broker.probe.timeout }}
         livenessProbe:
-          exec:
-            command:
-            - "/pulsar/health/broker_health_check.sh"
+          httpGet:
+            path: /status.html
+            port: {{ .Values.broker.probe.port }}
           initialDelaySeconds: {{ .Values.broker.probe.initial }}
           periodSeconds: {{ .Values.broker.probe.period }}
           timeoutSeconds: {{ .Values.broker.probe.timeout }}
@@ -241,6 +241,7 @@ spec:
           bin/apply-config-from-env.py conf/broker.conf &&
           bin/apply-config-from-env.py conf/client.conf &&
           bin/gen-yml-from-env.py conf/functions_worker.yml &&
+          echo "OK" > status &&
           {{- if .Values.enableTokenAuth }}
           cat /pulsar/token-superuser/superuser.jwt | tr -d '\n' > /pulsar/token-superuser-stripped.jwt &&
           {{- end }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -29,6 +29,7 @@ metadata:
     component: {{ .Values.brokerSts.component }}
     cluster: {{ template "pulsar.fullname" . }}
 data:
+  statusFilePath: "/pulsar/status"
   zookeeperServers:
     {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
     {{- if .Values.extra.zookeepernp }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
@@ -217,9 +217,9 @@ spec:
           periodSeconds:  {{ .Values.brokerSts.probe.period }}
           timeoutSeconds:  {{ .Values.brokerSts.probe.timeout }}
         livenessProbe:
-          exec:
-            command:
-            - "/pulsar/health/broker_health_check.sh"
+          httpGet:
+            path: /status.html
+            port: {{ .Values.broker.probe.port }}
           initialDelaySeconds: {{ .Values.brokerSts.probe.initial }}
           periodSeconds: {{ .Values.broker.probe.period }}
           timeoutSeconds: {{ .Values.broker.probe.timeout }}
@@ -238,6 +238,7 @@ spec:
           bin/apply-config-from-env.py conf/broker.conf &&
           bin/apply-config-from-env.py conf/client.conf &&
           bin/gen-yml-from-env.py conf/functions_worker.yml &&
+          echo "OK" > status &&
           {{- if .Values.enableTokenAuth }}
           cat /pulsar/token-superuser/superuser.jwt | tr -d '\n' > /pulsar/token-superuser-stripped.jwt &&
           {{- end }}


### PR DESCRIPTION
This brings the broker liveness probe in sync with the community Helm chart, and should use less resources than the health_check script.