### PR TITLE
Set 'clusterName' config in Proxy

### DIFF
--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -75,6 +75,7 @@ data:
   {{- if .Values.extra.function }}
   functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:6750"
   {{- end }}
+  clusterName: {{ template "pulsar.fullname" . }}
 {{- if .Values.enableTls }}
   tlsEnabledWithKeyStore: "true"
   tlsKeyStore: "/pulsar/tls.keystore.jks"


### PR DESCRIPTION
Proxy configMap doesn't set 'clusterName' in the proxy config.
This only impacts the proxy metrics where the label "cluster" is empty