### PR TITLE
Fix port definitions on proxy and websocket proxy containers

### DIFF
--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -258,8 +258,8 @@ spec:
           bin/apply-config-from-env.py conf/proxy.conf &&
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar proxy
         ports:
-        - name: wss
-          containerPort: 8001
+        - name: http
+          containerPort: 8080
         {{- if and .Values.proxy.extensions.enabled .Values.proxy.extensions.containerPorts }}
 {{ toYaml .Values.proxy.extensions.containerPorts | indent 8 }}
         {{- end }}
@@ -312,8 +312,8 @@ spec:
           bin/apply-config-from-env.py conf/websocket.conf &&
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar websocket
         ports:
-        - name: http
-          containerPort: 8080
+        - name: ws
+          containerPort: 8000
         {{- if or .Values.enableTls .Values.enableTokenAuth }}
         volumeMounts:
         {{- end }}


### PR DESCRIPTION
This is a cosmetic fix. The underlying functionality appears to have been working.