### PR TITLE
add option to enable transaction coord on existing pulsar cluster

### DIFF
--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-transactions-metadata.yaml
@@ -15,7 +15,8 @@
 #
 #
 {{- if .Values.extra.broker }}
-{{- if and .Values.broker.transactionCoordinator.enabled (or .Release.IsInstall .Values.initialize) }}
+{{- if and .Values.broker.transactionCoordinator.enabled
+           (or .Release.IsInstall .Values.initialize .Values.broker.transactionCoordinator.initialize) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-transactions-metadata.yaml
@@ -16,7 +16,8 @@
 #
 
 {{- if .Values.extra.brokerSts }}
-{{- if and .Values.brokerSts.transactionCoordinator.enabled (or .Release.IsInstall .Values.initialize) }}
+{{- if and .Values.brokerSts.transactionCoordinator.enabled
+           (or .Release.IsInstall .Values.initialize .Values.brokerSts.transactionCoordinator.initialize) }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -901,6 +901,8 @@ broker:
   # It runs the Transaction coordinator metadata setup job.
   transactionCoordinator:
     enabled: false
+    # set to true to manually initialize transaction coordinator on existing cluster
+    initialize: false
     # Count of partitions used for the transaction coordinator.
     initialCount: 16
   probe:


### PR DESCRIPTION
This provides an option to enable transactions on an existing cluster, vs. previously it could only be initialized when the broker is first installed.