### PR TITLE
Fix bookies metadata format if tls on zookeeper is enabled

### DIFF
--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -140,10 +140,26 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/bookkeeper.conf &&
+          {{- if and .Values.enableTls .Values.tls.bookkeeper.enabled }}
+          openssl pkcs8 -topk8 -inform PEM -outform PEM -in /pulsar/certs/tls.key -out /pulsar/tls-pk8.key -nocrypt &&
+          {{- end }}
+          {{- if and .Values.enableTls .Values.tls.zookeeper.enabled }}
+          /pulsar/tools/certconverter.sh &&
+          {{- end }}
           bin/bookkeeper shell metaformat --nonInteractive || true;
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+        volumeMounts:
+        {{- if .Values.enableTls}}
+        - name: certs
+          readOnly: true
+          mountPath: /pulsar/certs
+          {{- if .Values.tls.zookeeper.enabled}}
+        - name: certconverter
+          mountPath: /pulsar/tools
+          {{- end }}
+        {{- end }}
       securityContext:
         fsGroup: 0
       containers:


### PR DESCRIPTION
If tls enabled on zookeeper, the init container of the bookie statefulset always fails creating the zookeeper client because keys and certificates are not mounted in the container.

Since the init container command allows failures, it's hard to catch this issue