### PR TITLE
Add customConfiguration value for function worker

### DIFF
--- a/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-configmap.yaml
@@ -155,6 +155,9 @@ data:
       - {{ . | quote }}
     {{- end }}
     {{- end }}
+    {{- if .Values.function.customConfiguration }}
+{{ toYaml .Values.function.customConfiguration | indent 4 }}
+    {{- end }}
     connectorsDirectory: "./connectors"
     {{- if eq .Values.function.runtime "process" }}
     processContainerFactory:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1185,6 +1185,9 @@ function:
   ## properties map. For example, you might use this map to configure the openid-connect plugin.
   # customProperties: {}
 
+  ## Arbitrary custom function worker configuration can be added to functions_worker.yml using customConfiguration
+  # customConfiguration: {}
+
   ## Function configmap
   ## templates/function-configmap.yaml
   ##


### PR DESCRIPTION
We need the datastax pulsar helm chart to be configurable for the kubernetes `runtimeCustomerizerConfig`.

So far I have not seen how this is enabled using the helm chart so I've added a `customConfiguration` value to the `function-configmap.yaml` template.

This allows us to pass arbitrary configuration to be added to the function-worker(s):

```yaml
function:
  customConfiguration:
    runtimeCustomizerClassName: "org.apache.pulsar.functions.runtime.kubernetes.BasicKubernetesManifestCustomizer"
    runtimeCustomizerConfig:
      jobNamespace: pulsar
      extractLabels:
        extraLabel: value
      extraAnnotations:
        extraAnnotation: value
      nodeSelectorLabels:
        role: pulsar-functions
      tolerations:
      - key: role
        value: pulsar-functions
        effect: NoSchedule
      resourceRequirements:
        requests:
          cpu: '0.1'
          memory: 128Mi
```
