### PR TITLE
added env and envFrom for initContainers

### DIFF
--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
@@ -207,7 +207,7 @@ spec:
           - name: lib-data
             mountPath: {{ .Values.broker.initContainer.emptyDirPath }}
         {{- if .Values.broker.initContainer.env }}
-        env: 
+        env:
 {{ toYaml .Values.broker.initContainer.env | indent 10 }}
         {{- end }}
         {{- if .Values.broker.initContainer.envFrom }}

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-deployment.yaml
@@ -206,6 +206,14 @@ spec:
         volumeMounts:
           - name: lib-data
             mountPath: {{ .Values.broker.initContainer.emptyDirPath }}
+        {{- if .Values.broker.initContainer.env }}
+        env: 
+{{ toYaml .Values.broker.initContainer.env | indent 10 }}
+        {{- end }}
+        {{- if .Values.broker.initContainer.envFrom }}
+        envFrom:
+{{ toYaml .Values.broker.initContainer.envFrom | indent 10 }}
+        {{- end }}
       {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
@@ -208,6 +208,14 @@ spec:
         volumeMounts:
           - name: lib-data
             mountPath: {{ .Values.brokerSts.initContainer.emptyDirPath }}
+        {{- if .Values.brokerSts.initContainer.env }}
+        env: 
+{{ toYaml .Values.brokerSts.initContainer.env | indent 10 }}
+        {{- end }}
+        {{- if .Values.brokerSts.initContainer.envFrom }}
+        envFrom:
+{{ toYaml .Values.brokerSts.initContainer.envFrom | indent 10 }}
+        {{- end }}
       {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.brokerSts.component }}"

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-statefulset.yaml
@@ -209,7 +209,7 @@ spec:
           - name: lib-data
             mountPath: {{ .Values.brokerSts.initContainer.emptyDirPath }}
         {{- if .Values.brokerSts.initContainer.env }}
-        env: 
+        env:
 {{ toYaml .Values.brokerSts.initContainer.env | indent 10 }}
         {{- end }}
         {{- if .Values.brokerSts.initContainer.envFrom }}

--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -174,6 +174,14 @@ spec:
         volumeMounts:
           - name: extra-data
             mountPath: {{ .Values.function.initContainer.emptyDirPath }}
+        {{- if .Values.function.initContainer.env }}
+        env: 
+{{ toYaml .Values.function.initContainer.env | indent 10 }}
+        {{- end }}
+        {{- if .Values.function.initContainer.envFrom }}
+        envFrom:
+{{ toYaml .Values.function.initContainer.envFrom | indent 10 }}
+        {{- end }}
       {{- end }}
       securityContext:
         fsGroup: 0

--- a/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/function/function-statefulset.yaml
@@ -175,7 +175,7 @@ spec:
           - name: extra-data
             mountPath: {{ .Values.function.initContainer.emptyDirPath }}
         {{- if .Values.function.initContainer.env }}
-        env: 
+        env:
 {{ toYaml .Values.function.initContainer.env | indent 10 }}
         {{- end }}
         {{- if .Values.function.initContainer.envFrom }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -209,7 +209,7 @@ spec:
           - name: lib-data
             mountPath: {{ .Values.proxy.initContainer.emptyDirPath }}
         {{- if .Values.proxy.initContainer.env }}
-        env: 
+        env:
 {{ toYaml .Values.proxy.initContainer.env | indent 10 }}
         {{- end }}
         {{- if .Values.proxy.initContainer.envFrom }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-deployment.yaml
@@ -208,6 +208,14 @@ spec:
         volumeMounts:
           - name: lib-data
             mountPath: {{ .Values.proxy.initContainer.emptyDirPath }}
+        {{- if .Values.proxy.initContainer.env }}
+        env: 
+{{ toYaml .Values.proxy.initContainer.env | indent 10 }}
+        {{- end }}
+        {{- if .Values.proxy.initContainer.envFrom }}
+        envFrom:
+{{ toYaml .Values.proxy.initContainer.envFrom | indent 10 }}
+        {{- end }}
       {{- end }}
       containers:
 {{- if .Values.extra.kubectlProxy }}

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -925,7 +925,14 @@ broker:
   #   tag: latest
   #   pullPolicy: IfNotPresent
   #   command: ["cp", "-r", "/pulsar-libs", "/jars" ]
+  #   args: []
   #   emptyDirPath: "/jars"
+  #   env:
+  #   - name: 
+  #     value: 
+  #   envFrom:
+  #   - configMapRef:
+  #     name:
 
   # Comma delimited list of authentication providers
   authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
@@ -1039,7 +1046,14 @@ brokerSts:
   #   tag: latest
   #   pullPolicy: IfNotPresent
   #   command: ["cp", "-r", "/pulsar-libs", "/jars" ]
+  #   args: []
   #   emptyDirPath: "/jars"
+  #   env:
+  #   - name: 
+  #     value: 
+  #   envFrom:
+  #   - configMapRef:
+  #     name:
 
   # Comma delimited list of authentication providers
   authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
@@ -1174,8 +1188,15 @@ function:
   #   tag: latest
   #   pullPolicy: IfNotPresent
   #   command: ["cp", "-r", "/pulsar-connectors", "/connectors" ]
+  #   args: []
   #   emptyDirPath: "/connectors"
   #   mainContainerStartupCmd: "cp -f /connectors/pulsar-connectors/* /pulsar/connectors"
+  #   env:
+  #   - name: 
+  #     value: 
+  #   envFrom:
+  #   - configMapRef:
+  #     name:
 
   authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken,org.apache.pulsar.broker.authentication.AuthenticationProviderTls"
 
@@ -1383,7 +1404,14 @@ proxy:
   #   tag: latest
   #   pullPolicy: IfNotPresent
   #   command: ["cp", "-r", "/pulsar-libs", "/jars" ]
+  #   args: []
   #   emptyDirPath: "/jars"
+  #   env:
+  #   - name: 
+  #     value: 
+  #   envFrom:
+  #   - configMapRef:
+  #     name:
 
   # Comma delimited list of authentication providers
   authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -928,8 +928,8 @@ broker:
   #   args: []
   #   emptyDirPath: "/jars"
   #   env:
-  #   - name: 
-  #     value: 
+  #   - name:
+  #     value:
   #   envFrom:
   #   - configMapRef:
   #     name:
@@ -1049,8 +1049,8 @@ brokerSts:
   #   args: []
   #   emptyDirPath: "/jars"
   #   env:
-  #   - name: 
-  #     value: 
+  #   - name:
+  #     value:
   #   envFrom:
   #   - configMapRef:
   #     name:
@@ -1192,8 +1192,8 @@ function:
   #   emptyDirPath: "/connectors"
   #   mainContainerStartupCmd: "cp -f /connectors/pulsar-connectors/* /pulsar/connectors"
   #   env:
-  #   - name: 
-  #     value: 
+  #   - name:
+  #     value:
   #   envFrom:
   #   - configMapRef:
   #     name:
@@ -1407,8 +1407,8 @@ proxy:
   #   args: []
   #   emptyDirPath: "/jars"
   #   env:
-  #   - name: 
-  #     value: 
+  #   - name:
+  #     value:
   #   envFrom:
   #   - configMapRef:
   #     name:


### PR DESCRIPTION
`env` and `envFrom` were missing when running custom initContainers for proxy, broker, brokerSts and function deployments/statefulsets.

This adds those values, also I noticed `initContainer.args` is definied in the templates but was missing in values.yaml