### PR TITLE
feat: support cluster in-place migration

### DIFF
--- a/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-deployment.yaml
+++ b/helm-chart-sources/pulsar/templates/autorecovery/autorecovery-deployment.yaml
@@ -162,7 +162,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} ls /admin/clusters | grep "^\[.*{{ template "pulsar.fullname" . }}.*\]"; do
+            until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} ls /admin/clusters | grep "^\[.*{{ template "pulsar.cluster" . }}.*\]"; do
               sleep 3;
             done;
       {{- if .Values.autoRecovery.enableProvisionContainer }}

--- a/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -128,7 +128,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} ls /admin/clusters | grep "^\[.*{{ template "pulsar.fullname" . }}.*\]"; do
+            until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} ls /admin/clusters | grep "^\[.*{{ template "pulsar.cluster" . }}.*\]"; do
               sleep 3;
             done;
       # This initContainer will make sure that the bookkeeper

--- a/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-deployment/broker-configmap.yaml
@@ -57,7 +57,7 @@ data:
     {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- end }}
     {{- end }}
-  clusterName: {{ template "pulsar.fullname" . }}
+  clusterName: {{ template "pulsar.cluster" . }}
   {{- if .Values.broker.functionsWorkerEnabled }}
   functionsWorkerEnabled: "true"
   PF_pulsarFunctionsCluster: {{ template "pulsar.fullname" . }}

--- a/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/broker-sts/broker-sts-configmap.yaml
@@ -57,7 +57,7 @@ data:
     {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181
     {{- end }}
     {{- end }}
-  clusterName: {{ template "pulsar.fullname" . }}
+  clusterName: {{ template "pulsar.cluster" . }}
   {{- if .Values.brokerSts.functionsWorkerEnabled }}
   functionsWorkerEnabled: "true"
   PF_pulsarFunctionsCluster: {{ template "pulsar.fullname" . }}

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-configmap.yaml
@@ -75,7 +75,7 @@ data:
   {{- if .Values.extra.function }}
   functionWorkerWebServiceURL: "http://{{ template "pulsar.fullname" . }}-{{ .Values.function.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:6750"
   {{- end }}
-  clusterName: {{ template "pulsar.fullname" . }}
+  clusterName: {{ template "pulsar.cluster" . }}
 {{- if .Values.enableTls }}
   tlsEnabledWithKeyStore: "true"
   tlsKeyStore: "/pulsar/tls.keystore.jks"

--- a/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/proxy/proxy-ws-configmap.yaml
@@ -56,7 +56,7 @@ data:
     "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2181"
     {{- end }}
   {{- end }}
-  clusterName: {{ template "pulsar.fullname" . }}
+  clusterName: {{ template "pulsar.cluster" . }}
   webServicePort: "{{ .Values.proxy.wsProxyPort }}"
   {{- if .Values.enableTokenAuth }}
   brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"

--- a/helm-chart-sources/pulsar/templates/utils/_helpers.tpl
+++ b/helm-chart-sources/pulsar/templates/utils/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Pulsar Cluster Name.
+*/}}
+{{- define "pulsar.cluster" -}}
+{{- if .Values.clusterNameOverride }}
+{{- .Values.clusterNameOverride }}
+{{- else }}
+{{- template "pulsar.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
 Necessary to make proper names for keycloak services (note that it is important that
 the .Chart.Name for the keycloak dependent chart does not change.)
 */}}

--- a/helm-chart-sources/pulsar/templates/zookeeper/gen-zk-conf.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/gen-zk-conf.yaml
@@ -1,0 +1,84 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-genzkconf-configmap"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "pulsar.name" . }}
+    chart: {{ template "pulsar.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: {{ .Values.zookeeper.component }}
+    cluster: {{ template "pulsar.fullname" . }}
+data:
+  gen-zk-conf.sh: |
+    #!/bin/bash
+    
+    # Apply env variables to config file and start the regular command
+    
+    CONF_FILE=$1
+    IDX=$2
+    PEER_TYPE=$3
+    
+    if [ $? != 0 ]; then
+        echo "Error: Failed to apply changes to config file"
+        exit 1
+    fi
+    
+    DOMAIN=`hostname -d`
+
+    if [ -n "${ZOOKEEPER_DOMAIN}" ]; then
+        ZOOKEEPER_DOMAIN="${ZOOKEEPER_DOMAIN}.$(cut -d '.' -f 2- <<<${DOMAIN})"
+    else
+        ZOOKEEPER_DOMAIN=$DOMAIN
+    fi
+    
+    # Generate list of servers and detect the current server ID,
+    # based on the hostname
+    ((IDX++))
+    for SERVER in $(echo $ZOOKEEPER_SERVERS | tr "," "\n")
+    do
+        echo "server.$IDX=$SERVER.$ZOOKEEPER_DOMAIN:2888:3888:${PEER_TYPE};2181" >> $CONF_FILE
+    
+        if [ "$HOSTNAME" == "$SERVER" ]; then
+            MY_ID=$IDX
+            echo "Current server id $MY_ID"
+        fi
+    
+    	((IDX++))
+    done
+
+    if [ -n "${OBSERVER_SERVER}" ]; then
+        echo "server.$IDX=${OBSERVER_SERVER}.$DOMAIN:2181:2888:observer" >> $CONF_FILE
+        MY_ID=$IDX
+    fi
+
+    # For ZooKeeper container we need to initialize the ZK id
+    if [ ! -z "$MY_ID" ]; then
+        # Get ZK data dir
+        DATA_DIR=`grep '^dataDir=' $CONF_FILE | awk -F= '{print $2}'`
+        if [ ! -e $DATA_DIR/myid ]; then
+            echo "Creating $DATA_DIR/myid with id = $MY_ID"
+            mkdir -p $DATA_DIR
+            echo $MY_ID > $DATA_DIR/myid
+        fi
+    fi

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -36,6 +36,11 @@ data:
   sslQuorum: "true"
   PULSAR_PREFIX_sslQuorum: "true"
   {{- end }}
+  PULSAR_PREFIX_peerType: {{ .Values.zookeeper.peerType }}
+  {{- if .Values.zookeeper.reconfig.enabled }}
+  PULSAR_PREFIX_reconfigEnabled: "true"
+  PULSAR_PREFIX_skipACL: "yes"
+  {{- end }}
 {{- range $key, $val := $.Values.zookeeper.configData }}
   {{ $key }}: {{ $val | replace "\"" "" | trim | quote }}
 {{- end }}

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-metadata.yaml
@@ -95,7 +95,7 @@ spec:
             /pulsar/tools/certconverter.sh &&
             {{- end }}
             bin/pulsar initialize-cluster-metadata \
-              --cluster {{ template "pulsar.fullname" . }} \
+              --cluster {{ template "pulsar.cluster" . }} \
               {{- if .Values.tls.zookeeper.enabled }}
               --zookeeper {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281 \
               --configuration-store {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-ca.{{ template "pulsar.serviceDnsSuffix" . }}:2281 \

--- a/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/helm-chart-sources/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -120,7 +120,7 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}
       securityContext:
-        fsGroup: 0
+{{ toYaml .Values.zookeeper.securityContext | indent 8 }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
         image: "{{ .Values.image.zookeeper.repository }}:{{ .Values.image.zookeeper.tag }}"
@@ -139,7 +139,11 @@ spec:
           {{- if .Values.extra.zookeepernp }}
           /pulsar/zookeeper-config/generate-zookeeper-config-mixed.sh conf/zookeeper.conf &&
           {{- else }}
-          bin/generate-zookeeper-config.sh conf/zookeeper.conf &&
+          {{- range $server := .Values.zookeeper.reconfig.zkServers }}
+          echo "{{ $server }}" >> conf/zookeeper.conf &&
+          {{- end }}
+          bin/gen-zk-conf.sh conf/zookeeper.conf {{ .Values.zookeeper.initialMyId }} {{ .Values.zookeeper.peerType }} &&
+          cat conf/zookeeper.conf &&
           {{- end }}
           OPTS="${OPTS} -Dlog4j2.formatMsgNoLookups=true" exec bin/pulsar zookeeper
         ports:
@@ -196,6 +200,9 @@ spec:
         - name: zookeeper-config
           mountPath: /pulsar/zookeeper-config
         {{- end }}
+        - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-genzkconf"
+          mountPath: /pulsar/bin/gen-zk-conf.sh
+          subPath: gen-zk-conf.sh
       volumes:
       {{- if and .Values.enableTls .Values.tls.zookeeper.enabled}}
       - name: certs
@@ -216,6 +223,10 @@ spec:
           name: "{{ template "pulsar.fullname" . }}-zookeeper-config"
           defaultMode: 0755
     {{- end }}
+      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-genzkconf"
+        configMap:
+          name: "{{ template "pulsar.fullname" . }}-genzkconf-configmap"
+          defaultMode: 0755
 {{- if .Values.persistence }}
   volumeClaimTemplates:
   - metadata:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -21,6 +21,9 @@
 # Override for the name of the helm deployment
 fullnameOverride: pulsar
 
+# Override the cluster name
+clusterNameOverride: ''
+
 # DNS name for loadbalancer
 dnsName: pulsar.example.com
 

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -635,6 +635,22 @@ zookeeper:
     usePolicy: true
     maxUnavailable: 1
 
+  # The initial myid used for generating myid for each zookeeper pod
+  initialMyId: 0
+
+  # zookeeper peer type, can be either "participant" or "observer"
+  peerType: participant
+
+  ## reconfig settings
+  reconfig:
+    enabled: false
+    # The zookeeper servers to observe/join
+    zkServers: []
+
+  # Pod securityContext
+  securityContext:
+    fsGroup: 0
+
 ## Pulsar: Zookeeper cluster non persistent storage
 ## Used as floating Zookeeper to maintain quorum in AZ failures
 ## templates/zookeepernp-statefulset.yaml

--- a/tests/ct.yaml
+++ b/tests/ct.yaml
@@ -18,7 +18,7 @@
 remote: origin
 check-version-increment: false
 target-branch: release
-helm-extra-args: "--timeout 600s --debug"
+helm-extra-args: "--debug"
 chart-dirs:
   - helm-chart-sources
 chart-repos:


### PR DESCRIPTION
Two features are added to support cluster in-place migration:
- Allow zookeepers to join an existing zookeeper cluster
- Allow users to override the pulsar cluster name (to the name of an existing cluster)