### PR TITLE
pulsar-proxy: fix env var enable unauth metrics

### DIFF
--- a/examples/kafka/dev-values-tls-all-components-and-kafka-and-oauth2.yaml
+++ b/examples/kafka/dev-values-tls-all-components-and-kafka-and-oauth2.yaml
@@ -273,7 +273,7 @@ proxy:
     PULSAR_PREFIX_brokerDeleteInactiveTopicsEnabled: "false"
     PULSAR_PREFIX_kafkaTransactionCoordinatorEnabled: "true"
     PULSAR_PREFIX_kopTlsEnabledWithBroker: "true"
-    authenticateMetricsEndpoint: "true"
+    PULSAR_PREFIX_authenticateMetricsEndpoint: "true"
   autoPortAssign:
     enablePlainTextWithTLS: true
   service:

--- a/helm-chart-sources/pulsar/values.yaml
+++ b/helm-chart-sources/pulsar/values.yaml
@@ -1430,7 +1430,7 @@ proxy:
     PULSAR_LOG_ROOT_LEVEL: "info"
     PULSAR_EXTRA_OPTS: "-Dpulsar.log.root.level=info"
     # To disable authentication on the Prometheus /metrics endpoint
-    # authenticateMetricsEndpoint: "false"
+    # PULSAR_PREFIX_authenticateMetricsEndpoint: "false"
   wsProxyPort: 8000
   wsProxyPortTls: 8001
   ## Proxy loadbalancer service


### PR DESCRIPTION
The `bin/apply-config-from-env.py` script will not apply the `authenticateMetricsEndpoint` config value unless it's already set in `conf/proxy.conf`, which unfortunately in the `datastax/lunastreaming-all:2.10_5.1` image, it is not set...

It might be preferable in this case to have the example value to include the prefix to make proxy metrics a bit easier to enable.