### PR TITLE
Updated health-configmap.yaml to include new API for liveliness check for function worker

### DIFF
--- a/helm-chart-sources/pulsar/templates/utils/health-configmap.yaml
+++ b/helm-chart-sources/pulsar/templates/utils/health-configmap.yaml
@@ -47,6 +47,8 @@ data:
     #!/bin/bash
     {{- if .Values.enableTokenAuth }}
     curl -s --max-time {{ .Values.proxy.probe.timeout }} --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:{{ .Values.function.probe.port }}/metrics/ > /dev/null
+    curl -s --max-time {{ .Values.proxy.probe.timeout }} --fail -H "Authorization: Bearer $(cat /pulsar/token-superuser/superuser.jwt | tr -d '\r')" http://localhost:{{ .Values.function.probe.port }}/admin/v3/functions/live/ > /dev/null
     {{- else }}
     curl -s --max-time {{ .Values.proxy.probe.timeout }} --fail http://localhost:{{ .Values.function.probe.port }}/metrics/ > /dev/null
+    curl -s --max-time {{ .Values.proxy.probe.timeout }} --fail http://localhost:{{ .Values.function.probe.port }}/admin/v3/functions/live/ > /dev/null
     {{- end }}


### PR DESCRIPTION
This update introduces a new liveness check API endpoint (`/admin/v3/live`) for the function worker. This endpoint allows the system to check the current state of the function worker in addition to the existing health check API endpoint (`/metrics`).